### PR TITLE
Add Folder.findByInventoryPath

### DIFF
--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -53,6 +53,16 @@ class RbVmomi::VIM::Folder
     x if x.is_a? type
   end
 
+  # Retrieve a managed entity by inventory path.
+  # @param path [String] A path of the form "My Folder/My Datacenter/vm/Discovered VM/VM1"
+  # @return [VIM::ManagedEntity]
+  def findByInventoryPath path
+    propSpecs = {
+      :entity => self, :inventoryPath => path
+    }
+    x = _connection.searchIndex.FindByInventoryPath(propSpecs)
+  end
+
   # Alias to <tt>traverse path, type, true</tt>
   # @see #traverse
   def traverse! path, type=Object


### PR DESCRIPTION
Hi Rich/Christian,

  this trivial patch adds support for `findByInventoryPath`. Useful when, for example, you need to find all the entities located in a specific inventory folder. It's based on 9e6d3eb79fbe1c5f3911e3715fcc038275062fe6 which should correspond to what you get when you `gem install rbvmomi`.

  Thanks for your work. It allowed us to migrate a couple webapps from Windows, Ruby and a mess of PowerShell scripts, to just Linux and Ruby. Along with `RVC`, `rbvmomi` really makes my ops life easier. :)

cheers,
 --
Giuliano
