### PR TITLE
Fix rbvmomi name[0] for ruby 1.8.7

### DIFF
--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -203,8 +203,9 @@ class Connection < TrivialSoap
     when :base64Binary then BasicTypes::Binary
     when :KeyValue then BasicTypes::KeyValue
     else
-      if name[0].downcase == name[0]
-        name = "%s%s" % [name[0].upcase, name[1..-1]]
+      first_char = name[0].chr
+      if first_char.downcase == first_char
+        name = "%s%s" % [first_char.upcase, name[1..-1]]
       end
 
       if @loader.has? name

--- a/lib/rbvmomi/type_loader.rb
+++ b/lib/rbvmomi/type_loader.rb
@@ -54,8 +54,9 @@ class TypeLoader
   def get name
     fail unless name.is_a? String
 
-    if name[0].downcase == name[0]
-      name = "%s%s" % [name[0].upcase, name[1..-1]]
+    first_char = name[0].chr
+    if first_char.downcase == first_char
+      name = "%s%s" % [first_char.upcase, name[1..-1]]
     end
 
     return @loaded[name] if @loaded.member? name
@@ -75,8 +76,9 @@ class TypeLoader
         if value
           value['wsdl_name'] ||= name
         end
-        if name[0].downcase == name[0]
-          name = "%s%s" % [name[0].upcase, name[1..-1]]
+        first_char = name[0].chr
+        if first_char.downcase == first_char
+          name = "%s%s" % [first_char.upcase, name[1..-1]]
         end
         [name, value]
       end]


### PR DESCRIPTION
In ruby 1.9 string index 0 returns a char, where in 1.8.7 this returns
the ascii value. This fixs the issue in Ruby 1.8.7.
