### PR TITLE
Fix assumption that the time test is always in -0800

### DIFF
--- a/test/test_serialization.rb
+++ b/test/test_serialization.rb
@@ -287,9 +287,9 @@ class SerializationTest < Test::Unit::TestCase
   end
 
   def test_time
-    obj = Time.at DateTime.new(2011, 11, 16, 13, 36, 8, Rational(-8,24)).strftime("%s").to_i
+    obj = Time.at(DateTime.new(2011, 11, 16, 13, 36, 8, Rational(-8,24)).strftime("%s").to_i).getgm
     check <<-EOS, obj, 'xsd:dateTime', false
-<root>2011-11-16T13:36:08-08:00</root>
+<root>2011-11-16T21:36:08Z</root>
     EOS
   end
 


### PR DESCRIPTION
If you're (un?)fortunate enough not to live in California, the tests fail:

<pre>
# Running tests:

..............................................expected:
<root>2011-11-16T13:36:08-08:00</root>

got:
<root>2011-11-16T21:36:08+00:00</root>
</pre>
