### PR TITLE
nokogiri attributes workaround support for 1.6.x 

### DIFF
--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -42,10 +42,11 @@ class NewDeserializer
   end
 
   def deserialize node, type=nil
-    if type_attr = node['type']
-    elsif node.attributes['type']
-      # Work around for 1.5.x which doesn't populate node['type']
-      # XXX what changed
+    type_attr = node['type']
+
+    # Work around for 1.5.x which doesn't populate node['type']
+    # XXX what changed
+    if node.attributes['type'] and not type_attr
       type_attr = node.attributes['type'].value
     end
 


### PR DESCRIPTION
It appears the `node['type']` field isn't being populated with later versions of nokogiri (ie 1.6.1). So the condition for finding the type based on this value fails. It can still be accessed via `node.attributes` which seems to exist in both `1.4.1` to `1.6.1`.

This should fix that AnyType VMODL error. 
https://github.com/vmware/rbvmomi/issues/31
