### PR TITLE
Adding methods to easily add/remove vmdk disks to/from VM

### DIFF
--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -91,41 +91,36 @@ class RbVmomi::VIM::Datastore
   # @param path (optional) [String] Path to search for file under
   # @return [Array] of files found
   def files_in_sub path
-    unless path.nil?
-      @ds_path = "[#{self.info.name}] #{path}"
-    else
-      @ds_path = "[#{self.info.name}]"
-    end
-    
-    @query_spec = file_query_spec
-    @return = self.browser.SearchDatastoreSubFolders_Task(:datastorePath => @ds_path, :searchSpec => @query_spec).wait_for_completion
-
-    unless @return.is_a? Array
-      @return = [*@return]
-    end
-
-    @return
+    find_files(path,true)
   end
 
   # Find all files in a datastore path
   # @param path (optional) [String] Path to search for file under
   # @return [Array] of files found
   def files_in_dir path
-    unless path.nil?
-      @ds_path = "[#{self.info.name}] #{path}"
-    else
+    find_files(path, false)
+  end
+
+  def find_files path, sub
+    if path.nil?
       @ds_path = "[#{self.info.name}]"
+    else
+      @ds_path = "[#{self.info.name}] #{path}"
     end
 
     @query_spec = file_query_spec
-    self.browser.SearchDatastore_Task(:datastorePath => @ds_path, :searchSpec => @query_spec).wait_for_completion
+    if sub
+      @return = self.browser.SearchDatastoreSubFolders_Task(:datastorePath => @ds_path, :searchSpec => @query_spec).wait_for_completion
+    else
+      @return = self.browser.SearchDatastore_Task(:datastorePath => @ds_path, :searchSpec => @query_spec).wait_for_completion
+    end
 
     unless @return.is_a? Array
       @return = [*@return]
     end
-
+    
     @return
-  end
+  end  
 
   private
 

--- a/lib/rbvmomi/vim/GuestProcessInfo.rb
+++ b/lib/rbvmomi/vim/GuestProcessInfo.rb
@@ -1,0 +1,3 @@
+class RbVmomi::VIM::GuestProcessInfo
+  attr_accessor :cmd_output
+end

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -70,5 +70,131 @@ class RbVmomi::VIM::VirtualMachine
       spec[:deviceChange] += device_change
     end
     spec
-  end 
+  end
+
+  # Retrieve all virtual controllers
+  # @return [Array] Array of virtual controllers
+  def controllers
+    self.config.hardware.device.grep(RbVmomi::VIM::VirtualController)
+  end
+
+  # Add specified file as a disk to VM
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore hosting the VMDK to be added
+  # @param file [String] the name of the file we want to add
+  # @param file_path (optional) [String] the path to the file
+  # @param controller (optional) [String] the controller to add the VirtualDisk to. 
+  #   Defaults to "SCSI controller 0"
+  # @return nil on success
+  def add_disk(options={})
+    defaults = {
+      :controller => "SCSI controller 0",
+    }
+    options = defaults.merge(options)
+    fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
+
+    @ds = options[:datastore]
+    @file = options[:file]
+    @file_path = options[:vmdk_path]
+    @controller = options[:controller]
+
+    if @vmdk_path.nil?
+      @file_path = @ds.find_file_path(@file)
+    else 
+      @file_path = @vmdk_path
+    end
+
+    @full_file_path = "[#{@ds.info.name}] #{@file_path}#{@file}"
+
+    @disk_backing_info = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(  :datastore => @ds, 
+                                                                            :fileName => @full_file_path, 
+                                                                            :diskMode => "persistent")
+
+    @vm_controllers = self.controllers
+
+    @vm_controller = nil
+    @vm_controllers.each { |c| @vm_controller = c if c.deviceInfo.label == @controller }
+    fail "Could not find Virtual Controller #{@controller}" if @vm_controller.nil?
+
+    # Because the unit number starts at 0, count will return the next value we can use
+    @unit_number = @vm_controller.device.count
+
+    @capacityKb  = @ds.get_file_info(:file => @file, :path => @file_path).capacityKb
+    @disk = RbVmomi::VIM::VirtualDisk.new(:controllerKey => @vm_controller.key, 
+                                          :unitNumber => @unit_number,
+                                          :key => -1,
+                                          :backing => @disk_backing_info,
+                                          :capacityInKB => @capacityKb)
+    @dev_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new(  :operation => RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('add'),
+                                                            :device => @disk)
+    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new( :deviceChange => [*@dev_spec] )
+
+    puts "Reconfiguring #{self.name} to add VMDK: #{@full_file_path}"
+    ReconfigVM_Task( :spec => @vm_spec ).wait_for_completion
+  end
+
+  # Remove specified disk from the VM
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore hosting the file to be removed
+  # @param file [String] the name of the disk file we want to remove
+  # @param file_path (optional) [String] the path to the disk file
+  # @param destroy (optional) [Boolean] whether or not to delete the underlying disk file
+  # @return nil on success
+  def remove_disk(options={})
+    defaults = {
+      :destroy => false,
+    }
+    options = defaults.merge(options)
+    @ds = options[:datastore]
+    @file = options[:file]
+    @file_path = options[:file_path]
+    @destroy = options[:destroy]
+
+    if @file_path.nil?
+      @file_path = @ds.find_file_path(@file)
+    end
+
+    fail "Please provide a datastore" unless @ds.is_a? RbVmomi::VIM::Datastore
+
+    @disk = self.find_disk(:datastore => @ds, :file => "#{@file_path}#{@file}")
+
+    fail "Couldn't find disk attached to #{self.name} for file #{@file}" if @disk.nil?
+
+    @config_remove_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('remove');
+    if @destroy
+      @config_destroy_operation = RbVmomi::VIM::VirtualDeviceConfigSpecFileOperation.new('destroy');
+      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
+                                                                :device => @disk,
+                                                                :fileOperations => @config_destroy_operation)
+
+      puts "Reconfiguring #{self.name} to destroy disk #{@file_path}#{@file}"
+    else
+      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
+                                                                :device => @disk)
+      puts "Reconfiguring #{self.name} to remove disk #{@file_path}#{@file}"
+    end
+
+    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new(:deviceChange => [*@device_spec])
+
+    ReconfigVM_Task(:spec => @vm_spec).wait_for_completion
+  end
+
+  # Find a disk attached to this VM
+  # @param file [String] the name of the file for the VirtualDisk
+  # @param datastore [RbVmomi::VIM::Datastore] the datastore to look for the disk in
+  # @return pRbVmomi::VIM::VirtualDevice] for the disk
+  def find_disk(options={})
+    @file = options[:file]
+    @datastore = options[:datastore]
+
+    @disk = nil
+    @devices = self.disks
+    @devices.each do |device|
+      next unless device.backing.is_a? RbVmomi::VIM::VirtualDeviceFileBackingInfo
+      @device_datastore,@device_file = device.backing.fileName.gsub(/(\[|\])/, '').split(' ')
+      if @device_file == @file and @device_datastore == @datastore.info.name
+        return device
+      end
+    end
+
+    fail "Didn't find disk for file #{@file}"
+  end
 end

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -89,43 +89,44 @@ class RbVmomi::VIM::VirtualMachine
   # @return nil on success
   def add_disk(options={})
     fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
-    @ds = options[:datastore]
-    @file = options[:file]
-    options[:controller] ||= "SCSI controller 0"
 
-    if options[:vmdk_path].nil?
-      @file_path = @ds.find_file_path(@file)
-    else 
-      @file_path = options[:vmdk_path]
+    ds = options[:datastore]
+    file = options[:file]
+    controller = options[:controller]
+    controller ||= "SCSI controller 0"
+    file_path = options[:file_path]
+
+    if file_path.nil?
+      file_path = ds.find_file_path(file)
     end
 
-    @full_file_path = "[#{@ds.info.name}] #{@file_path}#{@file}"
+    full_file_path = "[#{ds.info.name}] #{file_path}#{file}"
 
-    @disk_backing_info = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(  :datastore => @ds, 
-                                                                            :fileName => @full_file_path, 
+    disk_backing_info = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo.new(  :datastore => ds, 
+                                                                            :fileName => full_file_path, 
                                                                             :diskMode => "persistent")
 
-    @vm_controllers = self.controllers
+    vm_controllers = self.controllers
 
-    @vm_controller = nil
-    @vm_controllers.each { |c| @vm_controller = c if c.deviceInfo.label == options[:controller] }
-    fail "Could not find Virtual Controller #{options[:controller]}" if @vm_controller.nil?
+    vm_controller = nil
+    vm_controllers.each { |c| vm_controller = c if c.deviceInfo.label == controller }
+    fail "Could not find Virtual Controller #{controller}" if vm_controller.nil?
 
     # Because the unit number starts at 0, count will return the next value we can use
-    @unit_number = @vm_controller.device.count
+    unit_number = vm_controller.device.count
 
-    @capacityKb  = @ds.get_file_info(:file => @file, :path => @file_path).capacityKb
-    @disk = RbVmomi::VIM::VirtualDisk.new(:controllerKey => @vm_controller.key, 
-                                          :unitNumber => @unit_number,
+    capacityKb  = ds.get_file_info(file).capacityKb
+    disk = RbVmomi::VIM::VirtualDisk.new(:controllerKey => vm_controller.key, 
+                                          :unitNumber => unit_number,
                                           :key => -1,
-                                          :backing => @disk_backing_info,
-                                          :capacityInKB => @capacityKb)
-    @dev_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new(  :operation => RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('add'),
-                                                            :device => @disk)
-    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new( :deviceChange => [*@dev_spec] )
+                                          :backing => disk_backing_info,
+                                          :capacityInKB => capacityKb)
+    dev_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new(  :operation => RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('add'),
+                                                            :device => disk)
+    vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new( :deviceChange => [*dev_spec] )
 
-    puts "Reconfiguring #{self.name} to add VMDK: #{@full_file_path}"
-    ReconfigVM_Task( :spec => @vm_spec ).wait_for_completion
+    puts "Reconfiguring #{self.name} to add VMDK: #{full_file_path}"
+    self.ReconfigVM_Task( :spec => vm_spec ).wait_for_completion
   end
 
   # Remove specified disk from the VM
@@ -135,48 +136,55 @@ class RbVmomi::VIM::VirtualMachine
   # @param destroy (optional) [Boolean] whether or not to delete the underlying disk file
   # @return nil on success
   def remove_disk(options={})
-    fail "Please provide a datastore" unless @ds.is_a? RbVmomi::VIM::Datastore
-    @ds = options[:datastore]
-    @file = options[:file]
-    @file_path = options[:file_path]
-    options[:destroy] ||= false
-    if @file_path.nil?
-      @file_path = @ds.find_file_path(@file)
+    fail "Please provide a datastore" unless options[:datastore].is_a? RbVmomi::VIM::Datastore
+
+    ds = options[:datastore]
+    file = options[:file]
+    file_path = options[:file_path]
+    destroy = options[:destroy]
+    destroy ||= false
+
+    if file_path.nil?
+      file_path = ds.find_file_path(file)
     end
 
-    @disk = self.find_disk("#{@file_path}#{@file}", @ds)
+    disk = self.find_disk(:datastore => ds, :file => "#{file_path}#{file}")
 
-    fail "Couldn't find disk attached to #{self.name} for file #{@file}" if @disk.nil?
+    fail "Couldn't find disk attached to #{self.name} for file #{file}" if disk.nil?
 
-    @config_remove_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('remove');
-    if options[:destroy]
-      @config_destroy_operation = RbVmomi::VIM::VirtualDeviceConfigSpecFileOperation.new('destroy');
-      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
-                                                                :device => @disk,
-                                                                :fileOperations => @config_destroy_operation)
+    config_remove_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation.new('remove');
+    if destroy
+      config_destroy_operation = RbVmomi::VIM::VirtualDeviceConfigSpecFileOperation.new('destroy');
+      device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => config_remove_operation,
+                                                                :device => disk,
+                                                                :fileOperations => config_destroy_operation)
 
-      puts "Reconfiguring #{self.name} to destroy disk #{@file_path}#{@file}"
+      puts "Reconfiguring #{self.name} to destroy disk #{file_path}#{file}"
     else
-      @device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => @config_remove_operation,
-                                                                :device => @disk)
-      puts "Reconfiguring #{self.name} to remove disk #{@file_path}#{@file}"
+      device_spec = RbVmomi::VIM::VirtualDeviceConfigSpec.new( :operation => config_remove_operation,
+                                                                :device => disk)
+      puts "Reconfiguring #{self.name} to remove disk #{file_path}#{file}"
     end
 
-    @vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new(:deviceChange => [*@device_spec])
+    vm_spec = RbVmomi::VIM::VirtualMachineConfigSpec.new(:deviceChange => [*device_spec])
 
-    ReconfigVM_Task(:spec => @vm_spec).wait_for_completion
+    self.ReconfigVM_Task(:spec => vm_spec).wait_for_completion
   end
 
   # Find a disk attached to this VM
   # @param file [String] the name of the file for the VirtualDisk
   # @param datastore [RbVmomi::VIM::Datastore] the datastore to look for the disk in
   # @return pRbVmomi::VIM::VirtualDevice] for the disk
-  def find_disk file, datastore
-    @devices = self.disks
-    @devices.each do |device|
+  def find_disk(options={})
+    file = options[:file]
+    datastore = options[:datastore]
+
+    disk = nil
+    devices = self.disks
+    devices.each do |device|
       next unless device.backing.is_a? RbVmomi::VIM::VirtualDeviceFileBackingInfo
-      @device_datastore,@device_file = device.backing.fileName.gsub(/(\[|\])/, '').split(' ')
-      if @device_file == file and @device_datastore == datastore.info.name
+      device_datastore, device_file = device.backing.fileName.match(/\[([^\]]*)\]\s?(.*)/).captures
+      if device_file =~ Regexp.new("#{file}$") and device_datastore == datastore.info.name
         return device
       end
     end


### PR DESCRIPTION
Create several new methods, specifically add_disk and remove_disk to allow disks to be easily added and removed to/from a VirtualMachine.

We're also adding a few other methods to Datastore class to find certain files and information about those files. Also methods to the VirtualMachine class to find all controllers and a specific disk.

Tested against vSphere 5.1 with VMDK disks
