### PR TITLE
Fix for "Permission was denied" issue in datacenter connection

### DIFF
--- a/lib/rbvmomi/vim/ServiceInstance.rb
+++ b/lib/rbvmomi/vim/ServiceInstance.rb
@@ -5,7 +5,7 @@ class RbVmomi::VIM::ServiceInstance
   # @return [Datacenter]
   def find_datacenter path=nil
     if path
-      content.rootFolder.traverse path, RbVmomi::VIM::Datacenter
+      content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == path }
     else
       content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).first
     end


### PR DESCRIPTION
My account doesn't have administrative permissions on vCenter. And because of that `find_datacenter` method fails with the next error:

```
C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/connection.rb:61:in `parse_response': NoPermission: Permission to perform this operation was denied. (RbVmomi::Fault)
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/connection.rb:90:in `call'
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/basic_types.rb:205:in `_call'
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/basic_types.rb:74:in `block (2
levels) in init'
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/vim/Folder.rb:7:in `find'
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/vim/Folder.rb:93:in `traverse'
        from C:/Ruby/lib/ruby/gems/2.0.0/gems/rbvmomi-1.8.1/lib/rbvmomi/vim/ServiceInstance.rb:8:in `find_datacenter'
        from dc.rb:3:in `<main>'
```

This pull request updates the method to work with less privileges.
