### PR TITLE
added to_json

### DIFF
--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -158,6 +158,12 @@ class DataObject < ObjectWithProperties
     q.text ')'
   end
 
+  def to_json(*args)
+    h = self.props
+    m = h.merge({ JSON.create_id => self.class.name })
+    m.to_json(*args)
+  end
+
   init
 end
 


### PR DESCRIPTION
Allows to_json to recurse thru DataObject objects. See http://stackoverflow.com/questions/24446978/how-can-i-get-rubys-json-to-follow-object-references-like-pry-pp