### PR TITLE
Remove rake/rdoctask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'yard'
 
 begin


### PR DESCRIPTION
Update to use rdoc/task instead of the obsolete rake/rdoctask currently there.

Related to: https://github.com/vmware/rbvmomi/issues/51
