### PR TITLE
Add rollupType to PerfCounter name

### DIFF
--- a/lib/rbvmomi/vim/PerfCounterInfo.rb
+++ b/lib/rbvmomi/vim/PerfCounterInfo.rb
@@ -20,7 +20,7 @@
 
 class RbVmomi::VIM::PerfCounterInfo
   def name
-    "#{groupInfo.key}.#{nameInfo.key}"
+    "#{groupInfo.key}.#{nameInfo.key}.#{rollupType}"
   end
 end
 


### PR DESCRIPTION
PerfCounters should be distinguished by group, counter and rollup type. 
