### PR TITLE
Cache ManagedObject properties

### DIFF
--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -164,11 +164,16 @@ end
 class ManagedObject < ObjectWithMethods
   def self.kind; :managed end
 
-  def initialize connection, ref
+  def initialize connection, ref, props={}
     super()
     @connection = connection
     @soap = @connection # XXX deprecated
     @ref = ref
+    if props == nil
+      @props = {}
+    else
+      @props = Hash[props.map { |k, v| [k.to_sym, v] }]
+    end
   end
 
   def _connection
@@ -180,19 +185,23 @@ class ManagedObject < ObjectWithMethods
   end
 
   def _get_property sym
-    ret = @connection.propertyCollector.RetrieveProperties(:specSet => [{
-      :propSet => [{ :type => self.class.wsdl_name, :pathSet => [sym.to_s] }],
-      :objectSet => [{ :obj => self }],
-    }])[0]
+    if !@props.include?(sym)
+      ret = @connection.propertyCollector.RetrieveProperties(:specSet => [{
+        :propSet => [{ :type => self.class.wsdl_name, :pathSet => [sym.to_s] }],
+        :objectSet => [{ :obj => self }],
+      }])[0]
 
-    if !ret
-      return nil
-    elsif ret.propSet.empty?
-      return nil if ret.missingSet.empty?
-      raise ret.missingSet[0].fault
-    else
-      ret.propSet[0].val
+      @props[sym] = if !ret
+                      nil
+                    elsif ret.propSet.empty?
+                      raise ret.missingSet[0].fault unless ret.missingSet.empty?
+                      nil
+                    else
+                      ret.propSet[0].val
+                    end
     end
+
+    @props[sym]
   end
 
   def _set_property sym, val


### PR DESCRIPTION
Wondering if there is any interest in caching properties of a `ManagedObject` in a `@props` hash similar to what is done with a `DataObject` [here](https://github.com/vmware/rbvmomi/blob/master/lib/rbvmomi/basic_types.rb#L100)?

This would let you pass any known properties to `initialize`, and any property that has to be fetched with `RetrieveProperties` would be cached so that multiple calls to `_get_property` on the same `sym` doesn't result in multiple `RetrieveProperties` calls.