### PR TITLE
Move Ruby 1.8/1.9 gem pinnings to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'json', '< 2' if RUBY_VERSION.start_with?('1.')
+gem 'nokogiri', '< 1.6' if RUBY_VERSION.start_with?('1.8.')

--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,19 @@ be used alongside the official documentation[http://pubs.vmware.com/vsphere-60/t
 
     gem install rbvmomi
 
+=== Support for older Ruby versions
+
+RbVmomi supports Ruby 1.8.7 and higher, but certain dependencies may need
+pinning to older versions to get a compatible set of gems.
+
+On Ruby 1.8.7:
+
+* use +nokogiri+ 1.5.x (Gemfile: <code>gem 'nokogiri', '< 1.6'</code>)
+
+On both Ruby 1.9 and 1.8.7:
+
+* use +json+ 1.x (Gemfile: <code>gem 'json', '< 2'</code>)
+
 == Usage
 
 A simple example of turning on a VM:

--- a/rbvmomi.gemspec
+++ b/rbvmomi.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.extensions << 'ext/mkrf_conf.rb'
 
   spec.add_runtime_dependency('builder', '~> 3.2')
-  spec.add_runtime_dependency('json', '~> 1.8')
-  spec.add_runtime_dependency('nokogiri', '~> 1.5.11')
+  spec.add_runtime_dependency('json', '>= 1.8')
+  spec.add_runtime_dependency('nokogiri', '~> 1.5')
   spec.add_runtime_dependency('trollop', '~> 2.1')
 
   spec.add_development_dependency('rake', '~> 10.5')


### PR DESCRIPTION
Allows users on newer rubies to run with current versions of nokogiri
required by Rails etc.