### PR TITLE
Fix system call parameter for STDOUT to use :out

### DIFF
--- a/lib/rbvmomi/vim/OvfManager.rb
+++ b/lib/rbvmomi/vim/OvfManager.rb
@@ -139,7 +139,7 @@ class RbVmomi::VIM::OvfManager
         # to the uploadCmd. It is not clear to me why, but that leads to 
         # trucation of the uploaded disk. Without this option curl can't tell
         # the progress, but who cares
-        system("#{downloadCmd} | #{uploadCmd}", STDOUT => "/dev/null")
+        system("#{downloadCmd} | #{uploadCmd}", :out => "/dev/null")
         
         keepAliveThread.kill
         keepAliveThread.join


### PR DESCRIPTION
:out is the preferred way to redirect child process output.  The current
code is passing STDOUT which is actually passing the file descriptor,
and works most of the time, but it will not work if the parent process
has changed STDOUT to a file descriptor that the child cannot use.

```ruby
[1] pry(main)> STDOUT = $stdout = StringIO.new
(pry):1: warning: already initialized constant STDOUT
=> #<StringIO:0x007fe119768610>
[2] pry(main)> system("echo 'hi'", STDOUT => "/dev/null")
ArgumentError: wrong exec option
from (pry):2:in `system'
(pry):2:in `<main>'
[3] pry(main)> system("echo 'hi'", :out => "/dev/null")
=> true
```

https://bugzilla.redhat.com/show_bug.cgi?id=1514618