### PR TITLE
vim.rb: enhance the logic of vim.rev.

### DIFF
--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -39,8 +39,7 @@ class VIM < Connection
     opts[:port] ||= (opts[:ssl] ? 443 : 80)
     opts[:path] ||= '/sdk'
     opts[:ns] ||= 'urn:vim25'
-    rev_given = opts[:rev] != nil
-    opts[:rev] = '6.5' unless rev_given
+    opts[:rev] = '6.5' if opts[:rev].nil?
     opts[:debug] = (!ENV['RBVMOMI_DEBUG'].empty? rescue false) unless opts.member? :debug
 
     conn = new(opts).tap do |vim|
@@ -61,10 +60,8 @@ class VIM < Connection
             vim.serviceContent.sessionManager.Login :userName => opts[:user], :password => opts[:password]
         end
       end
-      unless rev_given
-        rev = vim.serviceContent.about.apiVersion
-        vim.rev = [rev, '6.5'].min
-      end
+      rev = vim.serviceContent.about.apiVersion
+      vim.rev = [rev, opts[:rev]].min { |a, b| Gem::Version.new(a) <=> Gem::Version.new(b) }
     end
 
     at_exit { conn.close }

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -39,8 +39,7 @@ class VIM < Connection
     opts[:port] ||= (opts[:ssl] ? 443 : 80)
     opts[:path] ||= '/sdk'
     opts[:ns] ||= 'urn:vim25'
-    rev_given = opts[:rev] != nil
-    opts[:rev] = '6.5' unless rev_given
+    opts[:rev] = '6.5' if opts[:rev].nil?
     opts[:debug] = (!ENV['RBVMOMI_DEBUG'].empty? rescue false) unless opts.member? :debug
 
     conn = new(opts).tap do |vim|
@@ -61,10 +60,17 @@ class VIM < Connection
             vim.serviceContent.sessionManager.Login :userName => opts[:user], :password => opts[:password]
         end
       end
-      unless rev_given
-        rev = vim.serviceContent.about.apiVersion
-        vim.rev = [rev, '6.5'].min
-      end
+      # Version compare
+      vim.rev = [rev, opts[:rev]].min { |a, b|
+        a_parts = a.split('.')
+        b_parts = b.split('.')
+        result = 0
+        [a_parts.size, b_parts.size].min.times {|i|
+          result = (a_parts[i].to_i <=> b_parts[i].to_i)
+          break if result != 0
+        }
+        (result != 0) ? result : (a_parts.size <=> b_parts.size)
+      }
     end
 
     at_exit { conn.close }


### PR DESCRIPTION
1. No matter if rev is specified when calls RbVmomi.connect, vim.rev
   should be real version that effects current VIM connection.

   Without this fix, say, vSphere is 6.5, and we give 7.0 to
   RbVmomi.connect, then returned vim.rev will be 7.0. Even if we
   give 100.0, obviously 100.0 is not a reasonable vSphere version,
   returned vim.rev will still be 100.0.

   With this fix, returned vim.rev will be min value of vSphere
   version and specified rev. For example, vSphere version is 6.5, and
   we specify rev 100.0 to RbVmomi.connect, then returned vim.rev
   will be 6.5.

2. Enhanced version comparison.

   Without this fix, version comparison is done by string comparison,
   as a result "100.0" is smaller than "6.0". vSphere version has
   reached to 8.x, once it reaches to "10.0", this bug will be
   triggered.

   With this fix, a version number is split into parts by ".", then
   compare each part from left to right, so that "10.0" is bigger
   than "6.0".