### PR TITLE
ManagedObject.wait_until: replace WaitForUpdates with WaitForUpdatesEx

### DIFF
--- a/lib/rbvmomi/vim/ManagedObject.rb
+++ b/lib/rbvmomi/vim/ManagedObject.rb
@@ -17,7 +17,13 @@ class RbVmomi::VIM::ManagedObject
     }, :partialUpdates => false
     ver = ''
     loop do
-      result = _connection.propertyCollector.WaitForUpdates(:version => ver)
+      result = _connection.propertyCollector.WaitForUpdatesEx(
+          :version => ver,
+          :options => {:maxWaitSeconds => 300}
+      )
+      if result.nil?
+        next
+      end
       ver = result.version
       if x = b.call
         return x


### PR DESCRIPTION
WaitForUpdates has been depracted since 4.1, WaitForUpdatesEx is the offical replacement. WaitForUpdatesEx has an option to specify wait timeout. We recently often encounter ReadTimeout error against wait_until because some task took more than 10 minutes to finish, but local HTTP read timeout is 10 minutes. After this fix, we no longer see the error.