### PR TITLE
Fix gem install bundler for really old rubies (< 2.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ rvm:
   - 2.5.3
   - jruby-9.1.17.0
   - jruby-9.2.5.0
-before_install:
-  - gem install bundler


### PR DESCRIPTION
An appropriate bundler version is installed by rvm with the ruby version
requested.  Later if we gem install bundler it will fail on really old
rubies (< 2.3) because it tries to install bundler 2.0.

As long as the specific version of bundler doesn't matter we can just
use the bundler version that rvm installs.