### PR TITLE
Warning fixes

### DIFF
--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -23,7 +23,7 @@ class Connection < TrivialSoap
   attr_reader :profile_summary
   attr_accessor :profiling
   attr_reader :deserializer
-  
+
   def initialize opts
     @ns = opts[:ns] or fail "no namespace specified"
     @rev = opts[:rev] or fail "no revision specified"
@@ -32,7 +32,7 @@ class Connection < TrivialSoap
     @profiling = false
     super opts
   end
-  
+
   def reset_profiling
     @profile = {}
     @profile_summary = {:network_latency => 0, :request_emit => 0, :response_parse => 0, :num_calls => 0}
@@ -90,7 +90,7 @@ class Connection < TrivialSoap
 
     t3 = Time.now
     out = parse_response resp, desc['result']
-    
+
     if @profiling
       t4 = Time.now
       @profile[method] ||= []
@@ -98,8 +98,8 @@ class Connection < TrivialSoap
         :network_latency => (t3 - t2),
         :request_emit => t2 - t1,
         :response_parse => t4 - t3,
-        :params => params, 
-        :obj => this, 
+        :params => params,
+        :obj => this,
         :backtrace => caller,
         :request_size => body.length,
         :response_size => resp_size,
@@ -110,7 +110,7 @@ class Connection < TrivialSoap
       @profile_summary[:request_emit] += profile_info[:request_emit]
       @profile_summary[:num_calls] += 1
     end
-    
+
     out
   end
 
@@ -139,7 +139,7 @@ class Connection < TrivialSoap
     when BasicTypes::DataObject
       if expected and not expected >= o.class and not expected == BasicTypes::AnyType
         fail "expected #{expected.wsdl_name} for '#{name}', got #{o.class.wsdl_name} for field #{name.inspect}"
-      end 
+      end
       xml.tag! name, attrs.merge("xsi:type" => o.class.wsdl_name) do
         o.class.full_props_desc.each do |desc|
           if o.props.member? desc['name'].to_sym
@@ -223,7 +223,7 @@ class Connection < TrivialSoap
   def type name
     self.class.type name
   end
-  
+
   def instanceUuid
     nil
   end

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -101,7 +101,6 @@ class NewDeserializer
     obj = klass.new nil
     props = obj.props
     children = node.children.select(&:element?)
-    n = children.size
     i = 0
 
     klass.full_props_desc.each do |desc|
@@ -152,7 +151,7 @@ class NewDeserializer
       h[child.name] = child.content
     end
     [h['key'], h['value']]
-  end 
+  end
 end
 
 class OldDeserializer

--- a/lib/rbvmomi/type_loader.rb
+++ b/lib/rbvmomi/type_loader.rb
@@ -95,7 +95,7 @@ class TypeLoader
 
   def load_extension name
     @extension_dirs.map { |x| File.join(x, "#{name}.rb") }.
-                    select { |x| File.exists? x }.
+                    select { |x| File.exist? x }.
                     each { |x| load x }
   end
 

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -1,8 +1,6 @@
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 
-require 'rbvmomi'
-
 # Win32::SSPI is part of core on Windows
 begin
   require 'win32/sspi'

--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -67,7 +67,7 @@ class RbVmomi::VIM::Folder
     propSpecs = {
       :entity => self, :inventoryPath => path
     }
-    x = _connection.searchIndex.FindByInventoryPath(propSpecs)
+    _connection.searchIndex.FindByInventoryPath(propSpecs)
   end
 
   # Alias to <tt>traverse path, type, true</tt>

--- a/lib/rbvmomi/vim/HostSystem.rb
+++ b/lib/rbvmomi/vim/HostSystem.rb
@@ -115,12 +115,12 @@ class VIM::EsxcliNamespace
     conn.type(@type_info.wsdlName).new(conn, @instance)
   end
 
-  def method_missing name, *args
+  def method_missing(name, *args)
     name = name.to_s
     if @namespaces.member? name and args.empty?
       @namespaces[name]
     elsif @commands.member? name
-      @commands[name].call *args
+      @commands[name].call(*args)
     else
       raise NoMethodError
     end

--- a/lib/rbvmomi/vim/ManagedObject.rb
+++ b/lib/rbvmomi/vim/ManagedObject.rb
@@ -52,7 +52,7 @@ class RbVmomi::VIM::ManagedObject
   # @return [Array] Property values in same order as +pathSet+, or the return
   #                 value from the block if it is given.
   def collect *pathSet
-    h = collect! *pathSet
+    h = collect!(*pathSet)
     a = pathSet.map { |k| h[k.to_s] }
     if block_given?
       yield a

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -13,38 +13,36 @@ class RbVmomi::VIM::VirtualMachine
   def disks
     self.config.hardware.device.grep(RbVmomi::VIM::VirtualDisk)
   end
-  
-  # Get the IP of the guest, but only if it is not stale 
+
+  # Get the IP of the guest, but only if it is not stale
   # @return [String] Current IP reported (as per VMware Tools) or nil
-  def guest_ip 
+  def guest_ip
     g = self.guest
     if g.ipAddress && (g.toolsStatus == "toolsOk" || g.toolsStatus == "toolsOld")
       g.ipAddress
     else
       nil
     end
-  end  
+  end
 
   # Add a layer of delta disks (redo logs) in front of every disk on the VM.
   # This is similar to taking a snapshot and makes the VM a valid target for
   # creating a linked clone.
   #
-  # Background: The API for linked clones is quite strange. We can't create 
+  # Background: The API for linked clones is quite strange. We can't create
   # a linked straight from any VM. The disks of the VM for which we can create a
   # linked clone need to be read-only and thus VC demands that the VM we
   # are cloning from uses delta-disks. Only then it will allow us to
   # share the base disk.
   def add_delta_disk_layer_on_all_disks
-    devices,  = self.collect 'config.hardware.device'
-    disks = devices.grep(RbVmomi::VIM::VirtualDisk)
     spec = update_spec_add_delta_disk_layer_on_all_disks
     self.ReconfigVM_Task(:spec => spec).wait_for_completion
   end
-  
+
   # Updates a passed in spec to perform the task of adding a delta disk layer
   # on top of all disks. Does the same as add_delta_disk_layer_on_all_disks
-  # but instead of issuing the ReconfigVM_Task, it just constructs the 
-  # spec, so that the caller can batch a couple of updates into one 
+  # but instead of issuing the ReconfigVM_Task, it just constructs the
+  # spec, so that the caller can batch a couple of updates into one
   # ReconfigVM_Task.
   def update_spec_add_delta_disk_layer_on_all_disks spec = {}
     devices,  = self.collect 'config.hardware.device'
@@ -73,5 +71,5 @@ class RbVmomi::VIM::VirtualMachine
       spec[:deviceChange] += device_change
     end
     spec
-  end 
+  end
 end


### PR DESCRIPTION
This fixes various unused/uninitialized warnings, a circular require, ambiguous splat warnings, and strips some trailing whitespace to boot.

A couple warnings were somewhat concerning, mainly the unused variables in the `RbVmomi::VIM::VirtualMachine#add_delta_disk_layer_on_all_disks` and I'm not 100 percent sure there aren't some required side effects happening there.

Also, the `VIM::HostSystem#cli_info` method is defined twice, each with a different implementation. I'm not sure which one is the correct version.

Lastly, there's a `@loader` variable that's uninitialized, but I'm still pondering the best approach for fixing it.