### PR TITLE
Fix for multiple certificates not getting stored in cert store & removing un-necessary if condition

### DIFF
--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -41,7 +41,7 @@ class RbVmomi::TrivialSoap
       require 'net/https'
       @http.use_ssl = true
       if @opts[:insecure]
-        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @opts[:insecure]
+        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       else
         @http.cert_store = OpenSSL::X509::Store.new
         @http.cert_store.set_default_paths

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -45,8 +45,7 @@ class RbVmomi::TrivialSoap
       else
         @http.cert_store = OpenSSL::X509::Store.new
         @http.cert_store.set_default_paths
-        @http.cert = OpenSSL::X509::Certificate.new(@opts[:cert]) if @opts[:cert]
-        @http.cert_store.add_cert(@http.cert) if @http.cert
+        @http.cert_store.add_file(@opts[:cert]) if @opts[:cert]
         @http.key = OpenSSL::PKey::RSA.new(@opts[:key]) if @opts[:key]
       end
     end


### PR DESCRIPTION
As per the current behaviour, even if the the cert file provided to rbvmomi consists of multiple SSL certificates, only one of them is placed in the cert store.
replacing add_cert with add_file results in all the certificates in the file being placed in the cert store, thus correcting the behaviour.

Also, removed an un-necessary if condition-
if @opts[:insecure]