### PR TITLE
Use require_relative instead of require to speed up requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 /pkg/
 /vendor/bundle/
 /vmodl/
+*.gem

--- a/lib/rbvmomi.rb
+++ b/lib/rbvmomi.rb
@@ -10,7 +10,7 @@ module RbVmomi
   end
 end
 
-require 'rbvmomi/connection'
-require 'rbvmomi/sso'
-require 'rbvmomi/version'
-require 'rbvmomi/vim'
+require_relative 'rbvmomi/connection'
+require_relative 'rbvmomi/sso'
+require_relative 'rbvmomi/version'
+require_relative 'rbvmomi/vim'

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -3,11 +3,11 @@
 
 require 'time'
 require 'date'
-require 'rbvmomi/trivial_soap'
-require 'rbvmomi/basic_types'
-require 'rbvmomi/fault'
-require 'rbvmomi/type_loader'
-require 'rbvmomi/deserialization'
+require_relative 'trivial_soap'
+require_relative 'basic_types'
+require_relative 'fault'
+require_relative 'type_loader'
+require_relative 'deserialization'
 
 module RbVmomi
 

--- a/lib/rbvmomi/pbm.rb
+++ b/lib/rbvmomi/pbm.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 
-require 'rbvmomi'
+require_relative '../rbvmomi'
 
 module RbVmomi
 

--- a/lib/rbvmomi/sms.rb
+++ b/lib/rbvmomi/sms.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 
-require 'rbvmomi'
+require_relative '../rbvmomi'
 module RbVmomi
 
 # A connection to one vSphere SMS endpoint.

--- a/lib/rbvmomi/utils/deploy.rb
+++ b/lib/rbvmomi/utils/deploy.rb
@@ -3,7 +3,7 @@
 
 require 'open-uri'
 require 'nokogiri'
-require 'rbvmomi'
+require_relative '../../rbvmomi'
 
 # The cached ovf deployer is an optimization on top of regular OVF deployment
 # as it is offered by the VIM::OVFManager. Creating a VM becomes a multi-stage


### PR DESCRIPTION
require_relative is faster as it doesn't require traversing the
filesystem looking for the require.

See benchmarks here: https://github.com/rspec/rspec-expectations/pull/476#issuecomment-35848905

Signed-off-by: Tim Smith <tsmith@chef.io>