### PR TITLE
Add a script to verify vmodl.db from a wsdl file

### DIFF
--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -19,27 +19,19 @@ def parse_args(args)
 
   Optimist.die("You must provide a wsdl file and a vmodl file") if args.count < 2
 
-  wsdl_path = Pathname.new(args.shift)
+  wsdl_path = Pathname.new(args.shift).expand_path
   Optimist.die("You must pass a path to a wsdl file") if !wsdl_path.exist?
 
-  vmodl_path = Pathname.new(args.shift)
+  vmodl_path = Pathname.new(args.shift).expand_path
   Optimist.die("You must pass a path to the vmodl.db file") if !vmodl_path.exist?
 
   return wsdl_path, vmodl_path, opts
 end
 
-def in_directory(dir)
-  saved_dir = Dir.getwd
-  Dir.chdir(dir)
-  yield
-ensure
-  Dir.chdir(saved_dir)
-end
-
 def load_wsdl(path)
   # WSDL includes have to resolve in the local directory so we have to
   # change working directories to where the wsdl is
-  in_directory(path.dirname) do
+  Dir.chdir(path.dirname) do
     WSDL::Parser.new.parse(path.read)
   end
 end

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+
+require 'active_support/core_ext/enumerable'
+require 'active_support/inflector'
+require "optimist"
+require "pathname"
+require "rbvmomi"
+require "wsdl/parser"
+
+def parse_args(args)
+  Optimist.options do
+    banner <<~HELP
+      Usage:
+      verify-vim-wsdl.rb [path to wsdl] [path to vmodl.db]
+
+      --help, -h  Print this message and exit
+    HELP
+  end
+
+  Optimist.die("You must provide a wsdl file and a vmodl file") if args.count < 2
+
+  wsdl_path = Pathname.new(args.shift)
+  Optimist.die("You must pass a path to a wsdl file") if !wsdl_path.exist?
+
+  vmodl_path = Pathname.new(args.shift)
+  Optimist.die("You must pass a path to the vmodl.db file") if !vmodl_path.exist?
+
+  return wsdl_path, vmodl_path
+end
+
+def indirectory(dir)
+  saved_dir = Dir.getwd
+  Dir.chdir(dir)
+  yield
+ensure
+  Dir.chdir(saved_dir)
+end
+
+def load_wsdl(path)
+  workingdir = Dir.getwd
+
+  # WSDL includes have to resolve in the local directory so we have to
+  # change working directories to where the wsdl is
+  indirectory(path.dirname) do
+    WSDL::Parser.new.parse(path.read)
+  end
+end
+
+def load_vmodl(path)
+  Marshal.load(path.read)
+end
+
+# Normalize the type, some of these don't have RbVmomi equivalients such as xsd:long
+# and RbVmomi uses ManagedObjects not ManagedObjectReferences as parameters
+def wsdl_constantize(type)
+  type = type.split(":").last
+  type = "int"           if %w[long short byte].include?(type)
+  type = "float"         if type == "double"
+  type = "binary"        if type == "base64Binary"
+  type = "ManagedObject" if type == "ManagedObjectReference"
+
+  type.camelcase.safe_constantize ||
+    "RbVmomi::BasicTypes::#{type.camelcase}".safe_constantize ||
+    "RbVmomi::VIM::#{type.camelcase}".safe_constantize
+end
+
+wsdl_path, vmodl_path = parse_args(ARGV)
+
+vim   = load_wsdl(wsdl_path)
+vmodl = load_vmodl(vmodl_path)
+
+vim.collect_complextypes.each do |type|
+  type_name = type.name.name
+  vmodl_data = vmodl[type_name]
+
+  next if vmodl_data.nil?
+
+  elements_by_name = type.elements.index_by { |e| e.name.name }
+  vmodl_data["props"].each do |vmodl_prop|
+    wsdl_prop = elements_by_name[vmodl_prop["name"]]
+    next if wsdl_prop.nil?
+
+    vmodl_klass = wsdl_constantize(vmodl_prop["wsdl_type"])
+    wsdl_klass  = wsdl_constantize(wsdl_prop.type.source)
+
+    puts "#{type_name} #{wsdl_klass.wsdl_name} doesn't match #{vmodl_klass.wsdl_name}" unless vmodl_klass <= wsdl_klass
+  end
+end

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -9,12 +9,9 @@ require "wsdl/parser"
 
 def parse_args(args)
   opts = Optimist.options do
-    banner <<~HELP
+    usage <<~HELP
       Usage:
       verify-vim-wsdl.rb [path to wsdl] [path to vmodl.db]
-
-      --fix       Fix the wsdl types
-      --help, -h  Print this message and exit
     HELP
 
     opt :fix, "Optionally fix the wsdl types in the vmodl.db", :type => :boolean, :default => false

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -66,9 +66,8 @@ def wsdl_constantize(type)
   type = "binary"        if type == "base64Binary"
   type = "ManagedObject" if type == "ManagedObjectReference"
 
-  type.camelcase.safe_constantize ||
-    "RbVmomi::BasicTypes::#{type.camelcase}".safe_constantize ||
-    "RbVmomi::VIM::#{type.camelcase}".safe_constantize
+  type = type.camelcase
+  type.safe_constantize || "RbVmomi::BasicTypes::#{type}".safe_constantize || "RbVmomi::VIM::#{type}".safe_constantize
 end
 
 wsdl_path, vmodl_path, options = parse_args(ARGV)

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -31,7 +31,7 @@ def parse_args(args)
   return wsdl_path, vmodl_path, opts
 end
 
-def indirectory(dir)
+def in_directory(dir)
   saved_dir = Dir.getwd
   Dir.chdir(dir)
   yield
@@ -44,7 +44,7 @@ def load_wsdl(path)
 
   # WSDL includes have to resolve in the local directory so we have to
   # change working directories to where the wsdl is
-  indirectory(path.dirname) do
+  in_directory(path.dirname) do
     WSDL::Parser.new.parse(path.read)
   end
 end

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -57,7 +57,7 @@ def dump_vmodl(vmodl, path)
   File.write(path, Marshal.dump(vmodl))
 end
 
-# Normalize the type, some of these don't have RbVmomi equivalients such as xsd:long
+# Normalize the type, some of these don't have RbVmomi equivalents such as xsd:long
 # and RbVmomi uses ManagedObjects not ManagedObjectReferences as parameters
 def wsdl_constantize(type)
   type = type.split(":").last
@@ -91,7 +91,7 @@ vim.collect_complextypes.each do |type|
     wsdl_klass  = wsdl_constantize(wsdl_prop.type.source)
 
     unless vmodl_klass <= wsdl_klass
-      puts "#{type_name} #{wsdl_klass.wsdl_name} doesn't match #{vmodl_klass.wsdl_name}"
+      puts "#{type_name}.#{vmodl_prop["name"]} #{wsdl_klass.wsdl_name} doesn't match #{vmodl_klass.wsdl_name}"
       vmodl_prop["wsdl_type"] = wsdl_klass.wsdl_name if options[:fix]
     end
   end

--- a/rbvmomi.gemspec
+++ b/rbvmomi.gemspec
@@ -24,9 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('nokogiri', '~> 1.10')
   spec.add_runtime_dependency('optimist', '~> 3.0')
 
+  spec.add_development_dependency('activesupport')
   spec.add_development_dependency('pry', '~> 0.13.1')
   spec.add_development_dependency('rake', '~> 13.0')
   spec.add_development_dependency('simplecov', '~> 0.18.5')
+  spec.add_development_dependency('soap4r-ng', '~> 2.0')
   spec.add_development_dependency('yard', '~> 0.9.25')
   spec.add_development_dependency('test-unit', '~> 3.3')
 


### PR DESCRIPTION
This script parses the main vimService.wsdl and iterates through all of the ComplexTypes and checks that the params in the vmodl.db match the types from the WSDL.

It uses soap4r-ng which appears to be the only ruby soap wsdl parser that handles xsd:import/include directives which the VIM wsdls use extensively.  This saved me a lot of manual parsing and recursive xml walking.

Example:
```
HostProxySwitch.pnic xsd:string doesn't match PhysicalNic
HostMultipathInfoLogicalUnit.lun xsd:string doesn't match ScsiLun
HostMultipathInfoPath.adapter xsd:string doesn't match HostHostBusAdapter
HostMultipathInfoPath.lun xsd:string doesn't match HostMultipathInfoLogicalUnit
HostOpaqueSwitch.pnic xsd:string doesn't match PhysicalNic
HostPlugStoreTopologyAdapter.adapter xsd:string doesn't match HostHostBusAdapter
HostPlugStoreTopologyAdapter.path xsd:string doesn't match HostPlugStoreTopologyPath
HostPlugStoreTopologyPath.adapter xsd:string doesn't match HostPlugStoreTopologyAdapter
HostPlugStoreTopologyPath.target xsd:string doesn't match HostPlugStoreTopologyTarget
HostPlugStoreTopologyPath.device xsd:string doesn't match HostPlugStoreTopologyDevice
HostPlugStoreTopologyDevice.lun xsd:string doesn't match ScsiLun
HostPlugStoreTopologyDevice.path xsd:string doesn't match HostPlugStoreTopologyPath
HostPlugStoreTopologyPlugin.device xsd:string doesn't match HostPlugStoreTopologyDevice
HostPlugStoreTopologyPlugin.claimedPath xsd:string doesn't match HostPlugStoreTopologyPath
HostPortGroup.vswitch xsd:string doesn't match HostVirtualSwitch
HostVMotionNetConfig.selectedVnic xsd:string doesn't match HostVirtualNic
HostVirtualNic.port xsd:string doesn't match HostPortGroupPort
VirtualNicManagerNetConfig.selectedVnic xsd:string doesn't match HostVirtualNic
```