### PR TITLE
Turn warnings on for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList['test/test_*.rb']
   t.verbose = true
+  t.warning = true
 end
 
 YARD::Rake::YardocTask.new


### PR DESCRIPTION
I generally think it's a good idea to enable warnings for tests. With these on you will spot 2 issues:

* lib/rbvmomi/connection.rb:237: warning: instance variable `@loader` not initialized
* lib/rbvmomi/vim/HostSystem.rb:162: warning: method redefined; discarding old cli_info