### PR TITLE
Fix unescaped characters in Datastore URLs

### DIFF
--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -67,6 +67,6 @@ class RbVmomi::VIM::Datastore
 
   def mkuripath path
     datacenter_path_str = datacenter.path[1..-1].map{|elem| elem[1]}.join('/')
-    "/folder/#{URI.escape path}?dcPath=#{URI.escape datacenter_path_str }&dsName=#{URI.escape name}"
+    "/folder/#{URI.encode_www_form_component path}?dcPath=#{URI.encode_www_form_component datacenter_path_str }&dsName=#{URI.encode_www_form_component name}"
   end
 end


### PR DESCRIPTION
URI.escape doesn't escape some characters that are valid in datacenter,
datastore and folder names. Eg. &, ?, =, (, ). This can lead to invalid
URLs being generated.
Using URI.encode_www_form_component should correctly escape these
characters.