### PR TITLE
Improve #to_json behavior on RbVmomi Objects

### DIFF
--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -160,10 +160,22 @@ class DataObject < ObjectWithProperties
     q.text ')'
   end
 
-  def to_json(*args)
-    h = self.props
-    m = h.merge({ JSON.create_id => self.class.name })
-    m.to_json(*args)
+  def as_hash(val)
+    if val.kind_of?(Array)
+      val.map { |v| as_hash(v) }
+    elsif val.respond_to?(:to_hash)
+      val.to_hash
+    else
+      val
+    end
+  end
+
+  def to_hash
+    props.transform_values { |v| as_hash(v) }
+  end
+
+  def to_json(options = nil)
+    to_hash.merge(JSON.create_id => self.class.name).to_json
   end
 
   init
@@ -217,6 +229,10 @@ class ManagedObject < ObjectWithMethods
     "#{self.class.wsdl_name}(#{@ref.inspect})"
   end
 
+  def to_hash
+    to_s
+  end
+
   def pretty_print pp
     pp.text to_s
   end
@@ -256,6 +272,10 @@ class Enum < Base
 
   def initialize value
     @value = value
+  end
+
+  def to_hash
+    value
   end
 
   init

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -23,5 +23,57 @@ class MiscTest < Test::Unit::TestCase
     klass2 = VIM::HostSystem
     assert_equal klass, klass2
   end
-end
 
+  def test_managed_object_to_hash
+    assert_equal VIM.VirtualMachine(nil, "vm-123").to_hash, "VirtualMachine(\"vm-123\")"
+  end
+
+  def test_managed_object_to_json
+    assert_equal VIM.VirtualMachine(nil, "vm-123").to_json, "\"VirtualMachine(\\\"vm-123\\\")\""
+  end
+
+  def test_data_object_to_hash
+    # With a nested ManagedObject value
+    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, "vm-123")}).to_hash, {:vm => "VirtualMachine(\"vm-123\")"}
+
+    # With an array
+    assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).to_hash, {:customValue => [{key: 1}]}
+
+    # With an Enum
+    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus("green")}).to_hash, {:overallStatus => "green"}
+
+    # Combined
+    assert_equal VIM.VirtualMachineSummary(
+      :vm            => VIM.VirtualMachine(nil, "vm-123"),
+      :customValue   => [VIM.CustomFieldValue(:key => 1)],
+      :overallStatus => VIM.ManagedEntityStatus("green")
+    ).to_hash,
+    {
+      :vm            => "VirtualMachine(\"vm-123\")",
+      :customValue   => [{:key => 1}],
+      :overallStatus => "green"
+    }
+  end
+
+  def test_data_object_to_json
+    # With a nested ManagedObject value
+    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, "vm-123")}).to_json,
+                 "{\"vm\":\"VirtualMachine(\\\"vm-123\\\")\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+
+    # With an array
+    assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).to_json,
+                 "{\"customValue\":[{\"key\":1}],\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+
+    # With an Enum
+    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus("green")}).to_json,
+                 "{\"overallStatus\":\"green\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+
+    # Combined
+    assert_equal VIM.VirtualMachineSummary(
+      :vm            => VIM.VirtualMachine(nil, "vm-123"),
+      :customValue   => [VIM.CustomFieldValue(:key => 1)],
+      :overallStatus => VIM.ManagedEntityStatus("green")
+    ).to_json,
+    "{\"vm\":\"VirtualMachine(\\\"vm-123\\\")\",\"customValue\":[{\"key\":1}],\"overallStatus\":\"green\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+  end
+end


### PR DESCRIPTION
Draft pending tests

The `#to_json` method on `RbVmomi::BasicTypes::DataObject` doesn't work well with `ManagedObject` type objects as values (it tries to to_json the connection ivar and causes a stack overflow).

Example:
```
>> vm = RbVmomi::VIM::VirtualMachine(vim, "vm-953")
>> vm.summary.to_json
Traceback (most recent call last):
       16: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `as_json'
       15: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `map'
       14: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `each'
       13: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `block in as_json'
       12: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:56:in `as_json'
       11: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `as_json'
       10: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `map'
        9: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `each'
        8: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `block in as_json'
        7: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:56:in `as_json'
        6: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `as_json'
        5: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `map'
        4: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `each'
        3: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `block in as_json'
        2: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `dup'
        1: from activesupport (5.2.4.4) lib/active_support/core_ext/object/json.rb:171:in `initialize_dup'
SystemStackError (stack level too deep)
```

With this PR:

```
>> vm = RbVmomi::VIM::VirtualMachine(vim, "vm-953")
>> vm.summary.to_json
=> "{\"vm\":\"VirtualMachine(\\\"vm-953\\\")\",\"runtime\":{\"device\":[{\"runtimeState\":{\"vmDirectPathGen2Active\":false,\"vmDirectPathGen2InactiveReasonVm\":[], etc..
```

There are also times when we want to serialize a standard hash (for example saving to a rails `serialize` column or we want to serialize to YAML and we need to use basic types to be compatible with `YAML.safe_load`) 

```
>> pp vm.summary.to_hash
{:vm=>"VirtualMachine(\"vm-953\")",
 :runtime=>
  {:device=>
    [{:runtimeState=>
       {:vmDirectPathGen2Active=>false,
        :vmDirectPathGen2InactiveReasonVm=>[],
        :vmDirectPathGen2InactiveReasonOther=>["vmNptIncompatibleNetwork"],
        :attachmentStatus=>"",
        :featureRequirement=>[]},
      :key=>4000}]
 etc...
```

By extension this lets us `#to_json` on ManagedObjects which before tried to `to_json` the vim connection and would fail on a stack overflow
```
>> vm.to_json
=> "\"VirtualMachine(\\\"vm-953\\\")\""
```