### PR TITLE
Enforce single quotes for string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,8 @@
 AllCops:
   DisabledByDefault: true
 
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true
+
 # inherit_from: .rubocop_todo.yml

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'rubocop/rake_task'
 task(:default => :test)
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
+  t.libs << 'test'
   t.test_files = FileList['test/test_*.rb']
   t.verbose = true
   t.warning = true

--- a/devel/analyze-vim-declarations.rb
+++ b/devel/analyze-vim-declarations.rb
@@ -8,8 +8,8 @@ require 'pp'
 # :usage => analyze-vim-declarations.rb vim-declarations.xml foo-declarations.xml vmodl.db
 
 XML_FNS = ARGV[0...-1]
-abort "must specify path to vim-declarations.xml" if XML_FNS.empty?
-OUT_FN = ARGV[-1] or abort "must specify path to output database"
+abort 'must specify path to vim-declarations.xml' if XML_FNS.empty?
+OUT_FN = ARGV[-1] or abort 'must specify path to output database'
 
 XML_FNS.each do |x|
   abort "XML file #{x} does not exist" unless File.exists? x
@@ -135,7 +135,7 @@ end
 XML_FNS.each do |fn|
   puts "parsing #{fn} ..."
   xml_str = File.read(fn)
-  xml_str = xml_str.gsub(/\<description-html\>(.*?)\<\/description-html\>/m, "")
+  xml_str = xml_str.gsub(/\<description-html\>(.*?)\<\/description-html\>/m, '')
   xml = Nokogiri.parse(xml_str, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS)
   xml.root.at('enums').children.each { |x| handle_enum x }
   xml.root.at('managed-objects').children.each { |x| handle_managed_object x }

--- a/devel/analyze-xml.rb
+++ b/devel/analyze-xml.rb
@@ -5,7 +5,7 @@ require 'nokogiri'
 
 # removes line breaks and whitespace between xml nodes.
 def prepare_xml(xml)
-  xml = xml.gsub(/\n+/, "")
+  xml = xml.gsub(/\n+/, '')
   xml = xml.gsub(/(>)\s*(<)/, '\1\2')
 end
 

--- a/devel/benchmark.rb
+++ b/devel/benchmark.rb
@@ -58,45 +58,45 @@ if true
   new_libxml_result = RbVmomi::NewDeserializer.new($conn).deserialize libxml_xml
 
   if new_nokogiri_result != old_nokogiri_result
-    puts "new_nokogiri_result doesnt match old_nokogiri_result"
-    puts "old_nokogiri_result:"
+    puts 'new_nokogiri_result doesnt match old_nokogiri_result'
+    puts 'old_nokogiri_result:'
     pp old_nokogiri_result
-    puts "new_nokogiri_result:"
+    puts 'new_nokogiri_result:'
     pp new_nokogiri_result
-    puts "diff:"
+    puts 'diff:'
     diff old_nokogiri_result, new_nokogiri_result
     exit 1
   end
 
   if new_libxml_result != old_nokogiri_result
-    puts "new_libxml_result doesnt match old_nokogiri_result"
-    puts "old_nokogiri_result:"
+    puts 'new_libxml_result doesnt match old_nokogiri_result'
+    puts 'old_nokogiri_result:'
     pp old_nokogiri_result
-    puts "new_libxml_result:"
+    puts 'new_libxml_result:'
     pp new_libxml_result
-    puts "diff:"
+    puts 'diff:'
     diff old_nokogiri_result, new_libxml_result
     exit 1
   end
 
-  puts "all results match"
+  puts 'all results match'
 end
 
 Benchmark.bmbm do|b|
   GC.start
-  b.report("nokogiri parsing") do
+  b.report('nokogiri parsing') do
     N.times { Nokogiri::XML(raw) }
   end
   
   GC.start
-  b.report("libxml parsing") do
+  b.report('libxml parsing') do
     N.times do
       LibXML::XML::Parser.string(raw).parse
     end
   end
   
   GC.start
-  b.report("old deserialization (nokogiri)") do
+  b.report('old deserialization (nokogiri)') do
     deserializer = RbVmomi::OldDeserializer.new($conn)
     N.times do
       deserializer.deserialize Nokogiri::XML(raw).root
@@ -104,7 +104,7 @@ Benchmark.bmbm do|b|
   end
 
   GC.start
-  b.report("new deserialization (nokogiri)") do
+  b.report('new deserialization (nokogiri)') do
     deserializer = RbVmomi::NewDeserializer.new($conn)
     N.times do
       deserializer.deserialize Nokogiri::XML(raw).root
@@ -112,7 +112,7 @@ Benchmark.bmbm do|b|
   end
 
   GC.start
-  b.report("new deserialization (libxml)") do
+  b.report('new deserialization (libxml)') do
     deserializer = RbVmomi::NewDeserializer.new($conn)
     N.times do
       deserializer.deserialize LibXML::XML::Parser.string(raw).parse.root

--- a/devel/merge-internal-vmodl.rb
+++ b/devel/merge-internal-vmodl.rb
@@ -6,9 +6,9 @@
 # These types are not public and so may change between releases. Do not
 # use them directly.
 
-public_vmodl_filename = ARGV[0] or abort "public vmodl filename required"
-internal_vmodl_filename = ARGV[1] or abort "internal vmodl filename required"
-output_vmodl_filename = ARGV[2] or abort "output vmodl filename required"
+public_vmodl_filename = ARGV[0] or abort 'public vmodl filename required'
+internal_vmodl_filename = ARGV[1] or abort 'internal vmodl filename required'
+output_vmodl_filename = ARGV[2] or abort 'output vmodl filename required'
 
 TYPES = %w(
 DVSKeyedOpaqueData

--- a/devel/merge-manual-vmodl.rb
+++ b/devel/merge-manual-vmodl.rb
@@ -5,9 +5,9 @@
 
 # Manually merge two versions of vmodl.db
 
-public_vmodl_filename = ARGV[0] or abort "public vmodl filename required"
-internal_vmodl_filename = ARGV[1] or abort "internal vmodl filename required"
-output_vmodl_filename = ARGV[2] or abort "output vmodl filename required"
+public_vmodl_filename = ARGV[0] or abort 'public vmodl filename required'
+internal_vmodl_filename = ARGV[1] or abort 'internal vmodl filename required'
+output_vmodl_filename = ARGV[2] or abort 'output vmodl filename required'
 
 public_vmodl = File.open(public_vmodl_filename, 'r') { |io| Marshal.load io }
 internal_vmodl = File.open(internal_vmodl_filename, 'r') { |io| Marshal.load io }

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -2,10 +2,10 @@
 
 require 'active_support/core_ext/enumerable'
 require 'active_support/inflector'
-require "optimist"
-require "pathname"
-require "rbvmomi"
-require "wsdl/parser"
+require 'optimist'
+require 'pathname'
+require 'rbvmomi'
+require 'wsdl/parser'
 
 def parse_args(args)
   opts = Optimist.options do
@@ -14,16 +14,16 @@ def parse_args(args)
       verify-vim-wsdl.rb [path to wsdl] [path to vmodl.db]
     HELP
 
-    opt :fix, "Optionally fix the wsdl types in the vmodl.db", :type => :boolean, :default => false
+    opt :fix, 'Optionally fix the wsdl types in the vmodl.db', :type => :boolean, :default => false
   end
 
-  Optimist.die("You must provide a wsdl file and a vmodl file") if args.count < 2
+  Optimist.die('You must provide a wsdl file and a vmodl file') if args.count < 2
 
   wsdl_path = Pathname.new(args.shift).expand_path
-  Optimist.die("You must pass a path to a wsdl file") if !wsdl_path.exist?
+  Optimist.die('You must pass a path to a wsdl file') if !wsdl_path.exist?
 
   vmodl_path = Pathname.new(args.shift).expand_path
-  Optimist.die("You must pass a path to the vmodl.db file") if !vmodl_path.exist?
+  Optimist.die('You must pass a path to the vmodl.db file') if !vmodl_path.exist?
 
   return wsdl_path, vmodl_path, opts
 end
@@ -47,11 +47,11 @@ end
 # Normalize the type, some of these don't have RbVmomi equivalents such as xsd:long
 # and RbVmomi uses ManagedObjects not ManagedObjectReferences as parameters
 def wsdl_constantize(type)
-  type = type.split(":").last
-  type = "int"           if %w[long short byte].include?(type)
-  type = "float"         if type == "double"
-  type = "binary"        if type == "base64Binary"
-  type = "ManagedObject" if type == "ManagedObjectReference"
+  type = type.split(':').last
+  type = 'int'           if %w[long short byte].include?(type)
+  type = 'float'         if type == 'double'
+  type = 'binary'        if type == 'base64Binary'
+  type = 'ManagedObject' if type == 'ManagedObjectReference'
 
   type = type.camelcase
   type.safe_constantize || "RbVmomi::BasicTypes::#{type}".safe_constantize || "RbVmomi::VIM::#{type}".safe_constantize
@@ -79,11 +79,11 @@ vim.collect_complextypes.each do |type|
 
   # Loop through the properties defined in the vmodl.db for this type and
   # compare the type to that property as defined in the wsdl.
-  vmodl_data["props"].each do |vmodl_prop|
-    wsdl_prop = elements_by_name[vmodl_prop["name"]]
+  vmodl_data['props'].each do |vmodl_prop|
+    wsdl_prop = elements_by_name[vmodl_prop['name']]
     next if wsdl_prop.nil?
 
-    vmodl_klass = wsdl_constantize(vmodl_prop["wsdl_type"])
+    vmodl_klass = wsdl_constantize(vmodl_prop['wsdl_type'])
     wsdl_klass  = wsdl_constantize(wsdl_prop.type.source)
 
     # The vmodl class should be equal to or a subclass of the one in the wsdl.
@@ -91,7 +91,7 @@ vim.collect_complextypes.each do |type|
     # in the vmodl.db but it is a ManagedObjectReference in the wsdl.
     unless vmodl_klass <= wsdl_klass
       puts "#{type_name}.#{vmodl_prop["name"]} #{wsdl_klass.wsdl_name} doesn't match #{vmodl_klass.wsdl_name}"
-      vmodl_prop["wsdl_type"] = wsdl_klass.wsdl_name if options[:fix]
+      vmodl_prop['wsdl_type'] = wsdl_klass.wsdl_name if options[:fix]
     end
   end
 end

--- a/examples/annotate.rb
+++ b/examples/annotate.rb
@@ -38,20 +38,20 @@ Other options:
   stop_on CMDS
 end
 
-vm_name = ARGV[0] or Optimist.die("no VM name given")
-cmd = ARGV[1] or Optimist.die("no command given")
-abort "invalid command" unless CMDS.member? cmd
-Optimist.die("must specify host") unless opts[:host]
+vm_name = ARGV[0] or Optimist.die('no VM name given')
+cmd = ARGV[1] or Optimist.die('no command given')
+abort 'invalid command' unless CMDS.member? cmd
+Optimist.die('must specify host') unless opts[:host]
 
 vim = VIM.connect opts
 
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm = dc.find_vm(vm_name) or abort "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm = dc.find_vm(vm_name) or abort 'VM not found'
 
 case cmd
 when 'get'
   puts vm.config.annotation
 when 'set'
-  value = ARGV[2] or Optimist.die("no annotation given")
+  value = ARGV[2] or Optimist.die('no annotation given')
   vm.ReconfigVM_Task(:spec => VIM.VirtualMachineConfigSpec(:annotation => value)).wait_for_completion
 end

--- a/examples/cached_ovf_deploy.rb
+++ b/examples/cached_ovf_deploy.rb
@@ -37,23 +37,23 @@ VM location options:
 Other options:
   EOS
 
-  opt :template_name, "Name to give to the (cached) template", :type => :string
-  opt :template_path, "Path where templates are stored", :default => 'templates', :type => :string
-  opt :computer_path, "Path to the cluster to deploy into", :type => :string
-  opt :network, "Name of the network to attach template to", :type => :string
-  opt :vm_folder_path, "Path to VM folder to deploy VM into", :type => :string
-  opt :lease, "Lease in days", :type => :int, :default => 3
+  opt :template_name, 'Name to give to the (cached) template', :type => :string
+  opt :template_path, 'Path where templates are stored', :default => 'templates', :type => :string
+  opt :computer_path, 'Path to the cluster to deploy into', :type => :string
+  opt :network, 'Name of the network to attach template to', :type => :string
+  opt :vm_folder_path, 'Path to VM folder to deploy VM into', :type => :string
+  opt :lease, 'Lease in days', :type => :int, :default => 3
 end
 
-Optimist.die("must specify host") unless opts[:host]
-Optimist.die("no cluster path given") unless opts[:computer_path]
+Optimist.die('must specify host') unless opts[:host]
+Optimist.die('no cluster path given') unless opts[:computer_path]
 template_folder_path = opts[:template_path]
-template_name = opts[:template_name] or Optimist.die("no template name given")
-vm_name = ARGV[0] or Optimist.die("no VM name given")
-ovf_url = ARGV[1] or Optimist.die("No OVF URL given")
+template_name = opts[:template_name] or Optimist.die('no template name given')
+vm_name = ARGV[0] or Optimist.die('no VM name given')
+ovf_url = ARGV[1] or Optimist.die('No OVF URL given')
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 
 root_vm_folder = dc.vmFolder
 vm_folder = root_vm_folder

--- a/examples/clone_vm.rb
+++ b/examples/clone_vm.rb
@@ -33,17 +33,17 @@ VM location options:
 Other options:
   EOS
 
-  opt :linked_clone, "Use a linked clone instead of a full clone"
+  opt :linked_clone, 'Use a linked clone instead of a full clone'
 end
 
-Optimist.die("must specify host") unless opts[:host]
-ARGV.size == 2 or abort "must specify VM source name and VM target name"
+Optimist.die('must specify host') unless opts[:host]
+ARGV.size == 2 or abort 'must specify VM source name and VM target name'
 vm_source = ARGV[0]
 vm_target = ARGV[1]
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm = dc.find_vm(vm_source) or abort "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm = dc.find_vm(vm_source) or abort 'VM not found'
 
 if opts[:linked_clone]
   # The API for linked clones is quite strange. We can't create a linked

--- a/examples/create_vm-1.9.rb
+++ b/examples/create_vm-1.9.rb
@@ -34,11 +34,11 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-vm_name = ARGV[0] or abort "must specify VM name"
+Optimist.die('must specify host') unless opts[:host]
+vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 vmFolder = dc.vmFolder
 hosts = dc.hostFolder.children
 rp = hosts.first.resourcePool

--- a/examples/create_vm.rb
+++ b/examples/create_vm.rb
@@ -34,11 +34,11 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-vm_name = ARGV[0] or abort "must specify VM name"
+Optimist.die('must specify host') unless opts[:host]
+vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 vmFolder = dc.vmFolder
 hosts = dc.hostFolder.children
 rp = hosts.first.resourcePool

--- a/examples/customAttributes.rb
+++ b/examples/customAttributes.rb
@@ -41,14 +41,14 @@ Other options:
   stop_on CMDS
 end
 
-vm_name = ARGV[0] or Optimist.die("no VM name given")
-cmd     = ARGV[1] or Optimist.die("no command given")
-abort "invalid command" unless CMDS.member? cmd
-Optimist.die("must specify host") unless opts[:host]
+vm_name = ARGV[0] or Optimist.die('no VM name given')
+cmd     = ARGV[1] or Optimist.die('no command given')
+abort 'invalid command' unless CMDS.member? cmd
+Optimist.die('must specify host') unless opts[:host]
 
 vim = VIM.connect opts
-dc  = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm  = dc.find_vm(vm_name) or abort "VM not found"
+dc  = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm  = dc.find_vm(vm_name) or abort 'VM not found'
 
 case cmd
 when 'get'
@@ -64,8 +64,8 @@ when 'get'
   end
 when 'set'
   arrayCustomAttributes = []
-  customAttribute       = ARGV[2] or Optimist.die("no Custom Attribute given")
-  customAttributeValue  = ARGV[3] or Optimist.die("no value for the Custom Attribute given")
+  customAttribute       = ARGV[2] or Optimist.die('no Custom Attribute given')
+  customAttributeValue  = ARGV[3] or Optimist.die('no value for the Custom Attribute given')
   # Verify the Custom Attribute exists
   exists = 0
   vm.availableField.each do |af|
@@ -77,5 +77,5 @@ when 'set'
     end
   end
   exists == 1 or abort "Field \"#{customAttribute}\" doesn't exists\nPlease use one of the following:\n\t#{arrayCustomAttributes.join("\n\t")}"
-  vm.setCustomValue({"key" => "#{customAttribute}", :value => "#{customAttributeValue}"})
+  vm.setCustomValue({'key' => "#{customAttribute}", :value => "#{customAttributeValue}"})
 end

--- a/examples/delete_disk_from_vm.rb
+++ b/examples/delete_disk_from_vm.rb
@@ -29,14 +29,14 @@ VM location options:
     rbvmomi_datacenter_opt
 end
 
-Optimist.die("must specify host") unless opts[:host]
-ARGV.size == 2 or abort "must specify VM name and disk unit number"
+Optimist.die('must specify host') unless opts[:host]
+ARGV.size == 2 or abort 'must specify VM name and disk unit number'
 vm_name          = ARGV[0]
 disk_unit_number = ARGV[1].to_i
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm = dc.find_vm(vm_name) or abort "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm = dc.find_vm(vm_name) or abort 'VM not found'
 
 disk = vm.config.hardware.device.detect do |device|
   device.kind_of?(VIM::VirtualDisk) && device.unitNumber == disk_unit_number

--- a/examples/extraConfig.rb
+++ b/examples/extraConfig.rb
@@ -38,20 +38,20 @@ Other options:
   stop_on CMDS
 end
 
-vm_name = ARGV[0] or Optimist.die("no VM name given")
-cmd = ARGV[1] or Optimist.die("no command given")
-abort "invalid command" unless CMDS.member? cmd
-Optimist.die("must specify host") unless opts[:host]
+vm_name = ARGV[0] or Optimist.die('no VM name given')
+cmd = ARGV[1] or Optimist.die('no command given')
+abort 'invalid command' unless CMDS.member? cmd
+Optimist.die('must specify host') unless opts[:host]
 
 vim = VIM.connect opts
 
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm = dc.find_vm(vm_name) or abort "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm = dc.find_vm(vm_name) or abort 'VM not found'
 
 case cmd
 when 'list'
   vm.config.extraConfig.each { |x| puts "#{x.key}: #{x.value}" }
 when 'set'
-  extraConfig = ARGV[2..-1].map { |x| x.split("=", 2) }.map { |k,v| { :key => k, :value => v } }
+  extraConfig = ARGV[2..-1].map { |x| x.split('=', 2) }.map { |k,v| { :key => k, :value => v } }
   vm.ReconfigVM_Task(:spec => VIM.VirtualMachineConfigSpec(:extraConfig => extraConfig)).wait_for_completion
 end

--- a/examples/lease_tool.rb
+++ b/examples/lease_tool.rb
@@ -39,18 +39,18 @@ VM location options:
 Other options:
   EOS
 
-  opt :vm_folder_path, "Path to VM folder to deploy VM into", :type => :string
-  opt :force, "Really perform VMs. Used with kill_expired_vms"
+  opt :vm_folder_path, 'Path to VM folder to deploy VM into', :type => :string
+  opt :force, 'Really perform VMs. Used with kill_expired_vms'
 
   stop_on CMDS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-cmd = ARGV[0] or Optimist.die("no command given")
-Optimist.die("no vm folder path given") unless opts[:vm_folder_path]
+Optimist.die('must specify host') unless opts[:host]
+cmd = ARGV[0] or Optimist.die('no command given')
+Optimist.die('no vm folder path given') unless opts[:vm_folder_path]
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 
 root_vm_folder = dc.vmFolder
 vm_folder = root_vm_folder.traverse(opts[:vm_folder_path], VIM::Folder)
@@ -102,5 +102,5 @@ when 'show_soon_expired_vms'
     end
   end  
 else
-  abort "invalid command"
+  abort 'invalid command'
 end

--- a/examples/logbundle.rb
+++ b/examples/logbundle.rb
@@ -29,10 +29,10 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-dest = ARGV[0] or abort("must specify destination directory")
+Optimist.die('must specify host') unless opts[:host]
+dest = ARGV[0] or abort('must specify destination directory')
 
-abort "destination is not a directory" unless File.directory? dest
+abort 'destination is not a directory' unless File.directory? dest
 
 vim = VIM.connect opts
 is_vc = vim.serviceContent.about.apiType == 'VirtualCenter'

--- a/examples/logtail.rb
+++ b/examples/logtail.rb
@@ -29,14 +29,14 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
+Optimist.die('must specify host') unless opts[:host]
 logKey = ARGV[0]
 
 vim = VIM.connect opts
 diagMgr = vim.serviceContent.diagnosticManager
 
 if not logKey
-  puts "Available logs:"
+  puts 'Available logs:'
   diagMgr.QueryDescriptions.each do |desc|
     puts "#{desc.key}: #{desc.info.label}"
   end

--- a/examples/nfs_datastore.rb
+++ b/examples/nfs_datastore.rb
@@ -40,20 +40,20 @@ Other options:
   stop_on CMDS
 end
 
-Optimist.die("must specify host") unless opts[:host]
+Optimist.die('must specify host') unless opts[:host]
 
-cr_path = ARGV[0] or Optimist.die("no system name given")
-cmd = ARGV[1] or Optimist.die("no command given")
-abort "invalid command" unless CMDS.member? cmd
-nfs_spec = ARGV[2] or Optimist.die("no nfs path given")
-remoteHost, remotePath = nfs_spec.split(":")
+cr_path = ARGV[0] or Optimist.die('no system name given')
+cmd = ARGV[1] or Optimist.die('no command given')
+abort 'invalid command' unless CMDS.member? cmd
+nfs_spec = ARGV[2] or Optimist.die('no nfs path given')
+remoteHost, remotePath = nfs_spec.split(':')
 localPath = ARGV[3] || remoteHost
-mode = "readOnly" #hardcoded.
+mode = 'readOnly' #hardcoded.
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 cr = dc.find_compute_resource(cr_path) || dc.hostFolder.children.find(cr_path).first
-abort "compute resource not found" unless cr
+abort 'compute resource not found' unless cr
 
 case cr
 when VIM::ClusterComputeResource
@@ -61,7 +61,7 @@ when VIM::ClusterComputeResource
 when VIM::ComputeResource
   hosts = [cr]
 else
-  abort "invalid resource"
+  abort 'invalid resource'
 end
 
 hosts.each do |host|
@@ -94,6 +94,6 @@ hosts.each do |host|
       puts "not mounted on #{host.name}"
     end
   else
-    abort "invalid command"
+    abort 'invalid command'
   end
 end

--- a/examples/power.rb
+++ b/examples/power.rb
@@ -37,14 +37,14 @@ Other options:
   stop_on CMDS
 end
 
-cmd = ARGV[0] or Optimist.die("no command given")
-vm_name = ARGV[1] or Optimist.die("no VM name given")
-Optimist.die("must specify host") unless opts[:host]
+cmd = ARGV[0] or Optimist.die('no command given')
+vm_name = ARGV[1] or Optimist.die('no VM name given')
+Optimist.die('must specify host') unless opts[:host]
 
 vim = VIM.connect opts
 
-dc = vim.serviceInstance.content.rootFolder.traverse(opts[:datacenter], VIM::Datacenter) or abort "datacenter not found"
-vm = dc.vmFolder.traverse(vm_name, VIM::VirtualMachine) or abort "VM not found"
+dc = vim.serviceInstance.content.rootFolder.traverse(opts[:datacenter], VIM::Datacenter) or abort 'datacenter not found'
+vm = dc.vmFolder.traverse(vm_name, VIM::VirtualMachine) or abort 'VM not found'
 
 case cmd
 when 'on'
@@ -58,5 +58,5 @@ when 'suspend'
 when 'destroy'
   vm.Destroy_Task.wait_for_completion
 else
-  abort "invalid command"
+  abort 'invalid command'
 end

--- a/examples/readme-1.rb
+++ b/examples/readme-1.rb
@@ -29,10 +29,10 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-vm_name = ARGV[0] or abort "must specify VM name"
+Optimist.die('must specify host') unless opts[:host]
+vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = RbVmomi::VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or fail "datacenter not found"
-vm = dc.find_vm(vm_name) or fail "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or fail 'datacenter not found'
+vm = dc.find_vm(vm_name) or fail 'VM not found'
 vm.PowerOnVM_Task.wait_for_completion

--- a/examples/readme-2.rb
+++ b/examples/readme-2.rb
@@ -29,13 +29,13 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-vm_name = ARGV[0] or abort "must specify VM name"
+Optimist.die('must specify host') unless opts[:host]
+vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = RbVmomi::VIM.connect opts
 rootFolder = vim.serviceInstance.content.rootFolder
-dc = rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == opts[:datacenter] } or fail "datacenter not found"
-vm = dc.vmFolder.childEntity.grep(RbVmomi::VIM::VirtualMachine).find { |x| x.name == vm_name } or fail "VM not found"
+dc = rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == opts[:datacenter] } or fail 'datacenter not found'
+vm = dc.vmFolder.childEntity.grep(RbVmomi::VIM::VirtualMachine).find { |x| x.name == vm_name } or fail 'VM not found'
 task = vm.PowerOnVM_Task
 filter = vim.propertyCollector.CreateFilter(
   :spec => {

--- a/examples/screenshot.rb
+++ b/examples/screenshot.rb
@@ -35,14 +35,14 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
-vm_name = ARGV[0] or abort("must specify VM name")
-output_path = ARGV[1] or abort("must specify output filename")
+Optimist.die('must specify host') unless opts[:host]
+vm_name = ARGV[0] or abort('must specify VM name')
+output_path = ARGV[1] or abort('must specify output filename')
 
 vim = VIM.connect opts
 dc = vim.serviceInstance.find_datacenter(opts[:datacenter])
 vm = dc.find_vm vm_name
-abort "VM must be running" unless vm.runtime.powerState == 'poweredOn'
+abort 'VM must be running' unless vm.runtime.powerState == 'poweredOn'
 remote_path = vm.CreateScreenshot_Task.wait_for_completion
 remote_path =~ /^(\/vmfs\/volumes\/[^\/]+)\// or fail
 datastore_prefix = $1

--- a/examples/vdf.rb
+++ b/examples/vdf.rb
@@ -33,11 +33,11 @@ Other options:
   EOS
 end
 
-Optimist.die("must specify host") unless opts[:host]
+Optimist.die('must specify host') unless opts[:host]
 
 vim = VIM.connect opts
 
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
 
 def si n
   ['', 'K', 'M', 'G', 'T', 'P'].each_with_index do |x,i|
@@ -47,7 +47,7 @@ def si n
 end
 
 def unit n, u, p
-  "%.*g%s%s" % [p, si(n), u].flatten
+  '%.*g%s%s' % [p, si(n), u].flatten
 end
 
 def b n
@@ -55,7 +55,7 @@ def b n
 end
 
 puts "Filesystem#{' '*53}Size     Used     Avail    Use%     Mounted on"
-fmt = "%-62s %-8s %-8s %-8s %-8s %s"
+fmt = '%-62s %-8s %-8s %-8s %-8s %s'
 
 if false
   # simple version

--- a/examples/vm_drs_behavior.rb
+++ b/examples/vm_drs_behavior.rb
@@ -41,15 +41,15 @@ Other options:
   stop_on CMDS
 end
 
-Optimist.die("must specify host") unless opts[:host]
+Optimist.die('must specify host') unless opts[:host]
 
-vm_name = ARGV[0] or Optimist.die("no VM name given")
-cmd = ARGV[1] or Optimist.die("no command given")
-abort "invalid command" unless CMDS.member? cmd
+vm_name = ARGV[0] or Optimist.die('no VM name given')
+cmd = ARGV[1] or Optimist.die('no command given')
+abort 'invalid command' unless CMDS.member? cmd
 
 vim = VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort "datacenter not found"
-vm = dc.find_vm(vm_name) or abort "VM not found"
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or abort 'datacenter not found'
+vm = dc.find_vm(vm_name) or abort 'VM not found'
 
 cluster = vm.runtime.host.parent
 config = cluster.configurationEx.drsVmConfig.select {|c| c.key.name == vm.name }.first
@@ -64,14 +64,14 @@ when 'get'
   end
   puts "#{vm.name} is #{behavior}"
 when 'set'
-  behavior = ARGV[2] or Optimist.die("no behavior given")
-  abort "invalid behavior" unless BEHAVIOR.member? behavior
+  behavior = ARGV[2] or Optimist.die('no behavior given')
+  abort 'invalid behavior' unless BEHAVIOR.member? behavior
 
-  if behavior == "default"
+  if behavior == 'default'
     behavior = default
   end
   vm_spec =
-    VIM.ClusterDrsVmConfigSpec(:operation => VIM.ArrayUpdateOperation(config ? "edit" : "add"),
+    VIM.ClusterDrsVmConfigSpec(:operation => VIM.ArrayUpdateOperation(config ? 'edit' : 'add'),
                                :info => VIM.ClusterDrsVmConfigInfo(:key => vm,
                                                                    :behavior => VIM.DrsBehavior(behavior)))
   spec = VIM.ClusterConfigSpecEx(:drsVmConfigSpec => [vm_spec])

--- a/exe/rbvmomish
+++ b/exe/rbvmomish
@@ -45,7 +45,7 @@ rescue Errno::EHOSTUNREACH
 end
 
 typenames = VIM.loader.typenames
-Readline.completion_append_character = " "
+Readline.completion_append_character = ' '
 Readline.completion_proc = lambda do |word|
   return unless word
   prefix_regex = /^#{Regexp.escape(word)}/
@@ -68,12 +68,12 @@ def type name
   elsif klass < VIM::ManagedObject
     puts "Managed Object #{klass}"
     puts
-    puts "Properties:"
+    puts 'Properties:'
     klass.full_props_desc.each do |desc|
       puts " #{desc['name']}: #{q[desc['wsdl_type']]}#{desc['is-array'] ? '[]' : ''}"
     end
     puts
-    puts "Methods:"
+    puts 'Methods:'
     klass.full_methods_desc.sort_by(&:first).each do |name,desc|
       params = desc['params']
       puts " #{name}(#{params.map { |x| "#{x['name']} : #{q[x['wsdl_type'] || 'void']}#{x['is-array'] ? '[]' : ''}" } * ', '}) : #{q[desc['result']['wsdl_type'] || 'void']}"

--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -220,8 +220,8 @@ class ManagedObject < ObjectWithMethods
   end
 
   def _call method, o={}
-    fail "parameters must be passed as a hash" unless o.is_a? Hash
-    desc = self.class.full_methods_desc[method.to_s] or fail "unknown method"
+    fail 'parameters must be passed as a hash' unless o.is_a? Hash
+    desc = self.class.full_methods_desc[method.to_s] or fail 'unknown method'
     @connection.call method, desc, self, o
   end
 

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -25,8 +25,8 @@ class Connection < TrivialSoap
   attr_reader :deserializer
 
   def initialize opts
-    @ns = opts[:ns] or fail "no namespace specified"
-    @rev = opts[:rev] or fail "no revision specified"
+    @ns = opts[:ns] or fail 'no namespace specified'
+    @rev = opts[:rev] or fail 'no revision specified'
     @deserializer = Deserializer.new self
     reset_profiling
     @profiling = false
@@ -76,8 +76,8 @@ class Connection < TrivialSoap
   end
 
   def call method, desc, this, params
-    fail "this is not a managed object" unless this.is_a? BasicTypes::ManagedObject
-    fail "parameters must be passed as a hash" unless params.is_a? Hash
+    fail 'this is not a managed object' unless this.is_a? BasicTypes::ManagedObject
+    fail 'parameters must be passed as a hash' unless params.is_a? Hash
     fail unless desc.is_a? Hash
 
     t1 = Time.now
@@ -140,7 +140,7 @@ class Connection < TrivialSoap
       if expected and not expected >= o.class and not expected == BasicTypes::AnyType
         fail "expected #{expected.wsdl_name} for '#{name}', got #{o.class.wsdl_name} for field #{name.inspect}"
       end
-      xml.tag! name, attrs.merge("xsi:type" => o.class.wsdl_name) do
+      xml.tag! name, attrs.merge('xsi:type' => o.class.wsdl_name) do
         o.class.full_props_desc.each do |desc|
           if o.props.member? desc['name'].to_sym
             v = o.props[desc['name'].to_sym]
@@ -165,7 +165,7 @@ class Connection < TrivialSoap
     when Symbol, String
       if expected == BasicTypes::Binary
         attrs['xsi:type'] = 'xsd:base64Binary' if expected == BasicTypes::AnyType
-        xml.tag! name, [o].pack('m').chomp.gsub("\n", ""), attrs
+        xml.tag! name, [o].pack('m').chomp.gsub("\n", ''), attrs
       else
         attrs['xsi:type'] = 'xsd:string' if expected == BasicTypes::AnyType
         xml.tag! name, o.to_s, attrs
@@ -209,7 +209,7 @@ class Connection < TrivialSoap
     else
       first_char = name[0].chr
       if first_char.downcase == first_char
-        name = "%s%s" % [first_char.upcase, name[1..-1]]
+        name = '%s%s' % [first_char.upcase, name[1..-1]]
       end
 
       if @loader.has? name

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -74,14 +74,14 @@ class NewDeserializer
       end
     else
       if type =~ /:/
-        type = type.split(":", 2)[1]
+        type = type.split(':', 2)[1]
       end
       if type =~ /^ArrayOf/
         type = DEMANGLED_ARRAY_TYPES[$'] || $'
         return node.children.select(&:element?).map { |c| deserialize c, type }
       end
       if type =~ /:/
-        type = type.split(":", 2)[1]
+        type = type.split(':', 2)[1]
       end
 
       klass = @loader.get(type) or fail "no such type '#{type}'"
@@ -221,7 +221,7 @@ class OldDeserializer
     elsif t == BasicTypes::Binary
       xml.text.unpack('m')[0]
     elsif t == BasicTypes::AnyType
-      fail "attempted to deserialize an AnyType"
+      fail 'attempted to deserialize an AnyType'
     else fail "unexpected type #{t.inspect} (#{t.ancestors * '/'})"
     end
   rescue

--- a/lib/rbvmomi/optimist.rb
+++ b/lib/rbvmomi/optimist.rb
@@ -27,14 +27,14 @@ class Parser
   #  path: --path RBVMOMI_PATH (/sdk)
   #  debug: -d --debug RBVMOMI_DEBUG (false)
   def rbvmomi_connection_opts
-    opt :host, "host", :type => :string, :short => 'o', :default => ENV['RBVMOMI_HOST']
-    opt :port, "port", :type => :int, :short => :none, :default => (ENV.member?('RBVMOMI_PORT') ? ENV['RBVMOMI_PORT'].to_i : 443)
+    opt :host, 'host', :type => :string, :short => 'o', :default => ENV['RBVMOMI_HOST']
+    opt :port, 'port', :type => :int, :short => :none, :default => (ENV.member?('RBVMOMI_PORT') ? ENV['RBVMOMI_PORT'].to_i : 443)
     opt :"no-ssl", "don't use ssl", :short => :none, :default => (ENV['RBVMOMI_SSL'] == '0')
     opt :insecure, "don't verify ssl certificate", :short => 'k', :default => (ENV['RBVMOMI_INSECURE'] == '1')
-    opt :user, "username", :short => 'u', :default => (ENV['RBVMOMI_USER'] || 'root')
-    opt :password, "password", :short => 'p', :default => (ENV['RBVMOMI_PASSWORD'] || '')
-    opt :path, "SOAP endpoint path", :short => :none, :default => (ENV['RBVMOMI_PATH'] || '/sdk')
-    opt :debug, "Log SOAP messages", :short => 'd', :default => (ENV['RBVMOMI_DEBUG'] || false)
+    opt :user, 'username', :short => 'u', :default => (ENV['RBVMOMI_USER'] || 'root')
+    opt :password, 'password', :short => 'p', :default => (ENV['RBVMOMI_PASSWORD'] || '')
+    opt :path, 'SOAP endpoint path', :short => :none, :default => (ENV['RBVMOMI_PATH'] || '/sdk')
+    opt :debug, 'Log SOAP messages', :short => 'd', :default => (ENV['RBVMOMI_DEBUG'] || false)
   end
 
   # Select a datacenter
@@ -42,7 +42,7 @@ class Parser
   #  !!!plain
   #  datacenter: -D --datacenter RBVMOMI_DATACENTER (ha-datacenter)
   def rbvmomi_datacenter_opt
-    opt :datacenter, "datacenter", :type => :string, :short => "D", :default => (ENV['RBVMOMI_DATACENTER'] || 'ha-datacenter')
+    opt :datacenter, 'datacenter', :type => :string, :short => 'D', :default => (ENV['RBVMOMI_DATACENTER'] || 'ha-datacenter')
   end
 
   # Select a folder
@@ -50,7 +50,7 @@ class Parser
   #  !!!plain
   #  folder: -F --folder RBVMOMI_FOLDER ()
   def rbvmomi_folder_opt
-    opt :folder, "VM folder", :type => :string, :short => "F", :default => (ENV['RBVMOMI_FOLDER'] || '')
+    opt :folder, 'VM folder', :type => :string, :short => 'F', :default => (ENV['RBVMOMI_FOLDER'] || '')
   end
 
   # Select a compute resource
@@ -58,7 +58,7 @@ class Parser
   #  !!!plain
   #  computer: -R --computer RBVMOMI_COMPUTER
   def rbvmomi_computer_opt
-    opt :computer, "Compute resource", :type => :string, :short => "R", :default => (ENV['RBVMOMI_COMPUTER']||'ha-compute-res')
+    opt :computer, 'Compute resource', :type => :string, :short => 'R', :default => (ENV['RBVMOMI_COMPUTER']||'ha-compute-res')
   end
 
   # Select a datastore
@@ -66,7 +66,7 @@ class Parser
   #  !!!plain
   #  datastore: -s --datastore RBVMOMI_DATASTORE (datastore1)
   def rbvmomi_datastore_opt
-    opt :datastore, "Datastore", :short => 's', :default => (ENV['RBVMOMI_DATASTORE'] || 'datastore1')
+    opt :datastore, 'Datastore', :short => 's', :default => (ENV['RBVMOMI_DATASTORE'] || 'datastore1')
   end
 end
 end

--- a/lib/rbvmomi/pbm.rb
+++ b/lib/rbvmomi/pbm.rb
@@ -61,8 +61,8 @@ class PBM < Connection
     pp.text "PBM(#{@opts[:host]})"
   end
 
-  add_extension_dir File.join(File.dirname(__FILE__), "pbm")
-  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), "../../vmodl.db"))
+  add_extension_dir File.join(File.dirname(__FILE__), 'pbm')
+  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), '../../vmodl.db'))
 end
 
 end

--- a/lib/rbvmomi/sms.rb
+++ b/lib/rbvmomi/sms.rb
@@ -55,8 +55,8 @@ class SMS < Connection
     pp.text "SMS(#{@opts[:host]})"
   end
 
-  add_extension_dir File.join(File.dirname(__FILE__), "sms")
-  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), "../../vmodl.db"))
+  add_extension_dir File.join(File.dirname(__FILE__), 'sms')
+  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), '../../vmodl.db'))
 end
 
 end

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -82,7 +82,7 @@ class RbVmomi::TrivialSoap
     headers['cookie'] = @cookie if @cookie
 
     if @debug
-      $stderr.puts "Request:"
+      $stderr.puts 'Request:'
       $stderr.puts body
       $stderr.puts
     end
@@ -104,7 +104,7 @@ class RbVmomi::TrivialSoap
     end_time = Time.now
     
     if response.is_a? Net::HTTPServiceUnavailable
-      raise "Got HTTP 503: Service unavailable"
+      raise 'Got HTTP 503: Service unavailable'
     end
 
     self.cookie = response['set-cookie'] if response.key? 'set-cookie'

--- a/lib/rbvmomi/type_loader.rb
+++ b/lib/rbvmomi/type_loader.rb
@@ -58,7 +58,7 @@ class TypeLoader
 
     first_char = name[0].chr
     if first_char.downcase == first_char
-      name = "%s%s" % [first_char.upcase, name[1..-1]]
+      name = '%s%s' % [first_char.upcase, name[1..-1]]
     end
 
     return @loaded[name] if @loaded.member? name
@@ -80,7 +80,7 @@ class TypeLoader
         end
         first_char = name[0].chr
         if first_char.downcase == first_char
-          name = "%s%s" % [first_char.upcase, name[1..-1]]
+          name = '%s%s' % [first_char.upcase, name[1..-1]]
         end
         [name, value]
       end]

--- a/lib/rbvmomi/utils/admission_control.rb
+++ b/lib/rbvmomi/utils/admission_control.rb
@@ -223,7 +223,7 @@ class AdmissionControlledResourceScheduler
     # passed admission control. An exception is thrown if access was denied to 
     # all pods.
     if !@filtered_pods
-      log "Performing admission control:"
+      log 'Performing admission control:'
       @filtered_pods = self.pods.select do |pod|
         # Gather some statistics about the pod ...
         on_vms = pod_vms(pod).select{|k,v| v['runtime.powerState'] == 'poweredOn'}
@@ -240,7 +240,7 @@ class AdmissionControlledResourceScheduler
           ds_name = ds_props['name']
           free = ds_props['free_percent']
           free_gb = ds_props['summary'].freeSpace.to_f / 1024**3
-          free_str = "%.2f GB (%.2f%%)" % [free_gb, free]
+          free_str = '%.2f GB (%.2f%%)' % [free_gb, free]
           log "   Datastore #{ds_name}: #{free_str} free"
         end
         
@@ -263,7 +263,7 @@ class AdmissionControlledResourceScheduler
           end
           
           if low_list.length == pod_datastores.length
-            dsNames = low_list.map{|ds| @datastore_props[ds]['name']}.join(", ")
+            dsNames = low_list.map{|ds| @datastore_props[ds]['name']}.join(', ')
             err = "Datastores #{dsNames} below minimum free disk space (#{min_ds_free}%)"
             denied = true
           end
@@ -276,7 +276,7 @@ class AdmissionControlledResourceScheduler
             stats[:totalCPU] > 0 && stats[:totalMem] > 0
           end
           if !hosts_available
-            err = "No hosts are current available in this pod"
+            err = 'No hosts are current available in this pod'
             denied = true
           end
         end
@@ -284,7 +284,7 @@ class AdmissionControlledResourceScheduler
         if denied    
           log "   Admission DENIED: #{err}"
         else
-          log "   Admission granted"
+          log '   Admission granted'
         end
         
         !denied
@@ -295,7 +295,7 @@ class AdmissionControlledResourceScheduler
       if @service_docs_url
         log "Check #{@service_docs_url} to see which other Pods you may be able to use"
       end
-      fail "Admission denied"
+      fail 'Admission denied'
     end
     @filtered_pods
   end
@@ -324,7 +324,7 @@ class AdmissionControlledResourceScheduler
       end
     
       if !computer 
-        fail "No clusters available, should have been prevented by admission control"
+        fail 'No clusters available, should have been prevented by admission control'
       end
       @computer = computer
     end

--- a/lib/rbvmomi/utils/deploy.rb
+++ b/lib/rbvmomi/utils/deploy.rb
@@ -62,15 +62,15 @@ class CachedOvfDeployer
   # @param enabled [Boolean] If false, this function is a no-op
   def _run_without_interruptions enabled
     if enabled
-      int_handler = Signal.trap("SIGINT", 'IGNORE')
-      term_handler = Signal.trap("SIGTERM", 'IGNORE')
+      int_handler = Signal.trap('SIGINT', 'IGNORE')
+      term_handler = Signal.trap('SIGTERM', 'IGNORE')
     end
     
     yield
     
     if enabled
-      Signal.trap("SIGINT", int_handler)
-      Signal.trap("SIGTERM", term_handler)
+      Signal.trap('SIGINT', int_handler)
+      Signal.trap('SIGTERM', term_handler)
     end
   end
   
@@ -107,7 +107,7 @@ class CachedOvfDeployer
 
     # If we're handling a file:// URI we need to strip the scheme as open-uri
     # can't handle them.
-    if URI(ovf_url).scheme == "file" && URI(ovf_url).host.nil?
+    if URI(ovf_url).scheme == 'file' && URI(ovf_url).host.nil?
       ovf_url = URI(ovf_url).path
     end
 
@@ -138,7 +138,7 @@ class CachedOvfDeployer
       is_connected && is_ds_accessible && !host_props['runtime.inMaintenanceMode']
     end
     if !host
-      fail "No host in the cluster available to upload OVF to"
+      fail 'No host in the cluster available to upload OVF to'
     end
     
     log "Uploading OVF to #{hosts_props[host]['name']}..."
@@ -200,9 +200,9 @@ class CachedOvfDeployer
     # The losing thread now needs to wait for the winning thread to finish
     # uploading and preparing the template
     if wait_for_template
-      log "Template already exists, waiting for it to be ready"
+      log 'Template already exists, waiting for it to be ready'
       vm = _wait_for_template_ready @template_folder, vm_name
-      log "Template fully prepared and ready to be cloned"
+      log 'Template fully prepared and ready to be cloned'
     end
     
     vm
@@ -301,11 +301,11 @@ class CachedOvfDeployer
       # XXX: Optimize this
       vm = vm_folder.children.find{|x| x.name == vm_name}
     end
-    log "Template VM found"
+    log 'Template VM found'
     sleep 2
     while true
       runtime, template = vm.collect 'runtime', 'config.template'
-      ready = runtime && runtime.host && runtime.powerState == "poweredOff"
+      ready = runtime && runtime.host && runtime.powerState == 'poweredOff'
       ready = ready && template
       if ready
         break

--- a/lib/rbvmomi/utils/leases.rb
+++ b/lib/rbvmomi/utils/leases.rb
@@ -48,7 +48,7 @@ class LeaseTool
   # @return [Hash] Updated Virtual Machine config spec
   def set_lease_in_vm_config vmconfig, lease_minutes
     annotation = vmconfig[:annotation]
-    annotation ||= ""
+    annotation ||= ''
     note = YAML.load annotation
     if !note.is_a?(Hash)
       note = {}
@@ -87,7 +87,7 @@ class LeaseTool
   def set_lease_on_leaseless_vms vms, vmprops, opts = {}
     lease_minutes = opts[:lease_minutes]
     if !lease_minutes
-      raise "Expected lease_minutes to be specified"
+      raise 'Expected lease_minutes to be specified'
     end
     vms = find_leaseless_vms vms, vmprops
     if vms.length > 0

--- a/lib/rbvmomi/utils/perfdump.rb
+++ b/lib/rbvmomi/utils/perfdump.rb
@@ -201,7 +201,7 @@ class PerfAggregator
     end
     parent = objs[obj['parent']]
     _compute_vmfolder_and_rp_path_and_parents(vc, parent, objs)
-    obj['path'] = "%s/%s" % [parent['path'], obj['name']]
+    obj['path'] = '%s/%s' % [parent['path'], obj['name']]
     obj['parents'] = [obj['parent']] + parent['parents']
     nil
   end
@@ -348,7 +348,7 @@ class PerfAggregator
     vc_uuid = conn.instanceUuid
   
     connected_vms = vms_props.select do |vm, props| 
-      is_connected = props['runtime.connectionState'] != "disconnected"
+      is_connected = props['runtime.connectionState'] != 'disconnected'
       is_template = props['config.template']
       is_connected && !is_template
     end.keys
@@ -372,7 +372,7 @@ class PerfAggregator
     end
 
     connected_hosts = hosts_props.select do |k,v| 
-      v['runtime.connectionState'] != "disconnected"
+      v['runtime.connectionState'] != 'disconnected'
     end
     if connected_hosts.length > 0
       hosts_stats = pm.retrieve_stats(
@@ -440,7 +440,7 @@ class PerfAggregator
   end
   
   def collect_info_on_all_vms root_folders, opts = {}
-    log "Fetching information from all VCs ..." 
+    log 'Fetching information from all VCs ...' 
     vms_props = {}
     hosts_props = {}
     inventory = {}
@@ -469,17 +469,17 @@ class PerfAggregator
       end
     end.each{|t| t.join}
 
-    log "Make data marshal friendly ..." 
+    log 'Make data marshal friendly ...' 
     inventory = _make_marshal_friendly(inventory)
     vms_props = _make_marshal_friendly(vms_props)
     hosts_props = _make_marshal_friendly(hosts_props)
 
-    log "Perform external post processing ..." 
+    log 'Perform external post processing ...' 
     if @vm_processing_callback
       @vm_processing_callback.call(self, vms_props, inventory)
     end
     
-    log "Perform data aggregation ..." 
+    log 'Perform data aggregation ...' 
     # Processing the annotations may have added new nodes to the 
     # inventory list, hence we need to run _compute_parents_and_children
     # again to calculate the parents and children for the newly
@@ -492,7 +492,7 @@ class PerfAggregator
     path_types = opts[:path_types] || @path_types
     inventory = _aggregate_vms path_types, vms_props, inventory
     
-    log "Done collecting and aggregating stats"
+    log 'Done collecting and aggregating stats'
 
     @inventory = inventory
     @vms_props = vms_props
@@ -566,7 +566,7 @@ class PerfAggregator
         while parent_path
           parent = index[parent_path]
           if !parent
-            puts "Parent is nil, so dumping some stuff"
+            puts 'Parent is nil, so dumping some stuff'
             puts path_type
             puts "parent path: #{parent_path}"
             pp index.keys
@@ -601,7 +601,7 @@ class PerfAggregator
         indent, name, stats = row
         puts "#{'  ' * indent}#{name}: #{stats['num.vm']}"
       end
-      puts ""
+      puts ''
     end
   end
 

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -23,7 +23,7 @@ class VIM < Connection
   # @option opts [RbVmomi::SSO] :sso (nil) Use SSO token to login if set
   def self.connect opts
     fail unless opts.is_a? Hash
-    fail "host option required" unless opts[:host]
+    fail 'host option required' unless opts[:host]
     opts[:cookie] ||= nil
     opts[:user] ||= 'root'
     opts[:password] ||= ''
@@ -129,10 +129,10 @@ class VIM < Connection
     keys
   end
 
-  add_extension_dir File.join(File.dirname(__FILE__), "vim")
+  add_extension_dir File.join(File.dirname(__FILE__), 'vim')
   (ENV['RBVMOMI_VIM_EXTENSION_PATH']||'').split(':').each { |dir| add_extension_dir dir }
 
-  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), "../../vmodl.db"))
+  load_vmodl(ENV['VMODL'] || File.join(File.dirname(__FILE__), '../../vmodl.db'))
 end
 
 end

--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -5,7 +5,7 @@
 #       then set the +CURL+ environment variable to point to it.
 # @todo Use an HTTP library instead of executing +curl+.
 class RbVmomi::VIM::Datastore
-  CURLBIN = ENV['CURL'] || "curl" #@private
+  CURLBIN = ENV['CURL'] || 'curl' #@private
 
   # Check whether a file exists on this datastore.
   # @param path [String] Path on the datastore.
@@ -29,13 +29,13 @@ class RbVmomi::VIM::Datastore
   # @return [void]
   def download remote_path, local_path
     url = "http#{_connection.http.use_ssl? ? 's' : ''}://#{_connection.http.address}:#{_connection.http.port}#{mkuripath(remote_path)}"
-    pid = spawn CURLBIN, "-k", '--noproxy', '*', '-f',
-                "-o", local_path,
-                "-b", _connection.cookie,
+    pid = spawn CURLBIN, '-k', '--noproxy', '*', '-f',
+                '-o', local_path,
+                '-b', _connection.cookie,
                 url,
                 :out => '/dev/null'
     Process.waitpid(pid, 0)
-    fail "download failed" unless $?.success?
+    fail 'download failed' unless $?.success?
   end
 
   # Upload a file to this datastore.
@@ -44,13 +44,13 @@ class RbVmomi::VIM::Datastore
   # @return [void]
   def upload remote_path, local_path
     url = "http#{_connection.http.use_ssl? ? 's' : ''}://#{_connection.http.address}:#{_connection.http.port}#{mkuripath(remote_path)}"
-    pid = spawn CURLBIN, "-k", '--noproxy', '*', '-f',
-                "-T", local_path,
-                "-b", _connection.cookie,
+    pid = spawn CURLBIN, '-k', '--noproxy', '*', '-f',
+                '-T', local_path,
+                '-b', _connection.cookie,
                 url,
                 :out => '/dev/null'
     Process.waitpid(pid, 0)
-    fail "upload failed" unless $?.success?
+    fail 'upload failed' unless $?.success?
   end
 
   private

--- a/lib/rbvmomi/vim/DynamicTypeMgrDataTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrDataTypeInfo.rb
@@ -11,9 +11,9 @@ class RbVmomi::VIM::DynamicTypeMgrDataTypeInfo
         'props' => self.property.map do |prop|
           {
             'name' => prop.name,
-            'type-id-ref' => prop.type.gsub("[]", ""),
+            'type-id-ref' => prop.type.gsub('[]', ''),
             'is-array' => (prop.type =~ /\[\]$/) ? true : false,
-            'is-optional' => prop.annotation.find{|a| a.name == "optional"} ? true : false,
+            'is-optional' => prop.annotation.find{|a| a.name == 'optional'} ? true : false,
             'version-id-ref' => prop.version,
           }
         end,

--- a/lib/rbvmomi/vim/DynamicTypeMgrManagedTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrManagedTypeInfo.rb
@@ -11,9 +11,9 @@ class RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo
         'props' => self.property.map do |prop|
           {
             'name' => prop.name,
-            'type-id-ref' => prop.type.gsub("[]", ""),
+            'type-id-ref' => prop.type.gsub('[]', ''),
             'is-array' => (prop.type =~ /\[\]$/) ? true : false,
-            'is-optional' => prop.annotation.find{|a| a.name == "optional"} ? true : false,
+            'is-optional' => prop.annotation.find{|a| a.name == 'optional'} ? true : false,
             'version-id-ref' => prop.version,
           }
         end,
@@ -26,9 +26,9 @@ class RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo
                'params' => method.paramTypeInfo.map do |param|
                  {
                    'name' => param.name,
-                   'type-id-ref' => param.type.gsub("[]", ""),
+                   'type-id-ref' => param.type.gsub('[]', ''),
                    'is-array' => (param.type =~ /\[\]$/) ? true : false,
-                   'is-optional' => param.annotation.find{|a| a.name == "optional"} ? true : false,
+                   'is-optional' => param.annotation.find{|a| a.name == 'optional'} ? true : false,
                    'version-id-ref' => param.version,
                  }
                end,
@@ -38,9 +38,9 @@ class RbVmomi::VIM::DynamicTypeMgrManagedTypeInfo
                else
                  {
                    'name' => result.name,
-                   'type-id-ref' => result.type.gsub("[]", ""),
+                   'type-id-ref' => result.type.gsub('[]', ''),
                    'is-array' => (result.type =~ /\[\]$/) ? true : false,
-                   'is-optional' => result.annotation.find{|a| a.name == "optional"} ? true : false,
+                   'is-optional' => result.annotation.find{|a| a.name == 'optional'} ? true : false,
                    'version-id-ref' => result.version,
                  }
                end)

--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -127,12 +127,12 @@ class RbVmomi::VIM::Folder
     propSpecs.each do |k,v|
       case k
       when Class
-        fail "key must be a subclass of ManagedEntity" unless k < RbVmomi::VIM::ManagedEntity
+        fail 'key must be a subclass of ManagedEntity' unless k < RbVmomi::VIM::ManagedEntity
         k = k.wsdl_name
       when Symbol, String
         k = k.to_s
       else
-        fail "invalid key"
+        fail 'invalid key'
       end
 
       h = { :type => k }
@@ -141,7 +141,7 @@ class RbVmomi::VIM::Folder
       elsif v.is_a? Array
         h[:pathSet] = v + %w(parent)
       else
-        fail "value must be an array of property paths or :all"
+        fail 'value must be an array of property paths or :all'
       end
       propSet << h
     end

--- a/lib/rbvmomi/vim/HostSystem.rb
+++ b/lib/rbvmomi/vim/HostSystem.rb
@@ -16,10 +16,10 @@ class VIM::HostSystem
           if summary.config.product.version < '5.0.0' and direct?
             VIM::InternalDynamicTypeManager(_connection, 'ha-dynamic-type-manager')
           else
-            raise "esxcli not supported through VC before 5.0.0"
+            raise 'esxcli not supported through VC before 5.0.0'
           end
         else
-          raise "esxcli not supported before 4.1.0"
+          raise 'esxcli not supported before 4.1.0'
         end
       end
   end
@@ -106,7 +106,7 @@ class VIM::EsxcliNamespace
         @host.cli_info_fetcher.VimCLIInfoFetchCLIInfo(:typeName => type_name)
       else
         @host.mme.execute(@host.cli_info_fetcher._ref,
-                          "vim.CLIInfo.FetchCLIInfo", :typeName => type_name)
+                          'vim.CLIInfo.FetchCLIInfo', :typeName => type_name)
       end
   end
 

--- a/lib/rbvmomi/vim/ManagedEntity.rb
+++ b/lib/rbvmomi/vim/ManagedEntity.rb
@@ -17,12 +17,12 @@ class RbVmomi::VIM::ManagedEntity
           :obj => obj,
           :selectSet => [
             RbVmomi::VIM.TraversalSpec(
-              :name => "tsME",
+              :name => 'tsME',
               :type => 'ManagedEntity',
               :path => 'parent',
               :skip => false,
               :selectSet => [
-                RbVmomi::VIM.SelectionSpec(:name => "tsME")
+                RbVmomi::VIM.SelectionSpec(:name => 'tsME')
               ]
             )
           ]

--- a/lib/rbvmomi/vim/OvfManager.rb
+++ b/lib/rbvmomi/vim/OvfManager.rb
@@ -5,7 +5,7 @@
 #       then set the +CURL+ environment variable to point to it.
 # @todo Use an HTTP library instead of executing +curl+.
 class RbVmomi::VIM::OvfManager
-  CURLBIN = ENV['CURL'] || "curl" #@private
+  CURLBIN = ENV['CURL'] || 'curl' #@private
 
   # Deploy an OVF.
   #
@@ -31,9 +31,9 @@ class RbVmomi::VIM::OvfManager
 
     ovfImportSpec = RbVmomi::VIM::OvfCreateImportSpecParams(
       :hostSystem => opts[:host],
-      :locale => "US",
+      :locale => 'US',
       :entityName => opts[:vmName],
-      :deploymentOption => opts[:deploymentOption] || "",
+      :deploymentOption => opts[:deploymentOption] || '',
       :networkMapping => opts[:networkMappings].map{|from, to| RbVmomi::VIM::OvfNetworkMapping(:name => from, :network => to)},
       :propertyMapping => opts[:propertyMappings].to_a,
       :diskProvisioning => opts[:diskProvisioning]
@@ -65,14 +65,14 @@ class RbVmomi::VIM::OvfManager
                                               :folder => opts[:vmFolder],
                                               :host => opts[:host])
 
-    nfcLease.wait_until(:state) { nfcLease.state != "initializing" }
-    raise nfcLease.error if nfcLease.state == "error"
+    nfcLease.wait_until(:state) { nfcLease.state != 'initializing' }
+    raise nfcLease.error if nfcLease.state == 'error'
     begin
       nfcLease.HttpNfcLeaseProgress(:percent => 5)
       timeout, = nfcLease.collect 'info.leaseTimeout'
       puts "DEBUG: Timeout: #{timeout}"
       if timeout < 4 * 60
-        puts "WARNING: OVF upload NFC lease timeout less than 4 minutes"
+        puts 'WARNING: OVF upload NFC lease timeout less than 4 minutes'
       end
       progress = 5.0
       result.fileItem.each do |fileItem|
@@ -88,11 +88,11 @@ class RbVmomi::VIM::OvfManager
           leaseInfo, leaseState, leaseError = nfcLease.collect 'info', 'state', 'error'
           i += 1
         end
-        if leaseState != "ready"
+        if leaseState != 'ready'
           raise "NFC lease is no longer ready: #{leaseState}: #{leaseError}"
         end
         if leaseInfo == nil
-          raise "NFC lease disappeared?"
+          raise 'NFC lease disappeared?'
         end
         deviceUrl = leaseInfo.deviceUrl.find{|x| x.importKey == fileItem.deviceId}
         if !deviceUrl
@@ -103,14 +103,14 @@ class RbVmomi::VIM::OvfManager
         tmp = ovfFilename.split(/\//)
         tmp.pop
         tmp << fileItem.path
-        filename = tmp.join("/")
+        filename = tmp.join('/')
 
         # If filename doesn't have a URI scheme, we're considering it a local file
         if URI(filename).scheme.nil?
-          filename = "file://" + filename
+          filename = 'file://' + filename
         end
 
-        method = fileItem.create ? "PUT" : "POST"
+        method = fileItem.create ? 'PUT' : 'POST'
 
         keepAliveThread = Thread.new do
           while true
@@ -132,14 +132,14 @@ class RbVmomi::VIM::OvfManager
           i += 1
         end while i <= 5 && !ip
         raise "Couldn't get host's IP address" unless ip
-        href = deviceUrl.url.gsub("*", ip)
+        href = deviceUrl.url.gsub('*', ip)
         downloadCmd = "#{CURLBIN} -L '#{URI::escape(filename)}'"
         uploadCmd = "#{CURLBIN} -Ss -X #{method} --insecure -T - -H 'Content-Type: application/x-vnd.vmware-streamVmdk' '#{URI::escape(href)}'"
         # Previously we used to append "-H 'Content-Length: #{fileItem.size}'"
         # to the uploadCmd. It is not clear to me why, but that leads to 
         # trucation of the uploaded disk. Without this option curl can't tell
         # the progress, but who cares
-        system("#{downloadCmd} | #{uploadCmd}", :out => "/dev/null")
+        system("#{downloadCmd} | #{uploadCmd}", :out => '/dev/null')
         
         keepAliveThread.kill
         keepAliveThread.join
@@ -149,7 +149,7 @@ class RbVmomi::VIM::OvfManager
       end
 
       nfcLease.HttpNfcLeaseProgress(:percent => 100)
-      raise nfcLease.error if nfcLease.state == "error"
+      raise nfcLease.error if nfcLease.state == 'error'
       i = 1
       vm = nil
       begin
@@ -173,14 +173,14 @@ class RbVmomi::VIM::OvfManager
       i = 0
       begin
         nfcLease.HttpNfcLeaseComplete
-        puts "HttpNfcLeaseComplete succeeded"
+        puts 'HttpNfcLeaseComplete succeeded'
       rescue RbVmomi::VIM::InvalidState
-        puts "HttpNfcLeaseComplete already finished.."
+        puts 'HttpNfcLeaseComplete already finished..'
       rescue Exception => e
         puts "HttpNfcLeaseComplete failed at iteration #{i} with exception: #{e}"
         i += 1
         retry if i < 3
-        puts "Giving up HttpNfcLeaseComplete.."
+        puts 'Giving up HttpNfcLeaseComplete..'
       end
       vm
     end

--- a/lib/rbvmomi/vim/ResourcePool.rb
+++ b/lib/rbvmomi/vim/ResourcePool.rb
@@ -31,12 +31,12 @@ class RbVmomi::VIM::ResourcePool
           :obj => obj,
           :selectSet => [
             RbVmomi::VIM.TraversalSpec(
-              :name => "tsRP",
+              :name => 'tsRP',
               :type => 'ResourcePool',
               :path => 'resourcePool',
               :skip => false,
               :selectSet => [
-                RbVmomi::VIM.SelectionSpec(:name => "tsRP")
+                RbVmomi::VIM.SelectionSpec(:name => 'tsRP')
               ]
             )
           ]

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -18,7 +18,7 @@ class RbVmomi::VIM::VirtualMachine
   # @return [String] Current IP reported (as per VMware Tools) or nil
   def guest_ip
     g = self.guest
-    if g.ipAddress && (g.toolsStatus == "toolsOk" || g.toolsStatus == "toolsOld")
+    if g.ipAddress && (g.toolsStatus == 'toolsOk' || g.toolsStatus == 'toolsOld')
       g.ipAddress
     else
       nil

--- a/test/test_deserialization.rb
+++ b/test/test_deserialization.rb
@@ -28,12 +28,12 @@ class DeserializationTest < Test::Unit::TestCase
     obj = VIM.DatastoreSummary(
       :capacity => 1000,
       :accessible => true,
-      :datastore => VIM.Datastore(nil, "foo"),
+      :datastore => VIM.Datastore(nil, 'foo'),
       :freeSpace => 31,
       :multipleHostAccess => false,
-      :name => "baz",
-      :type => "VMFS",
-      :url => "http://foo/"
+      :name => 'baz',
+      :type => 'VMFS',
+      :url => 'http://foo/'
     )
 
     check <<-EOS, obj, 'DatastoreSummary'
@@ -130,7 +130,7 @@ end
 
   def test_fault
     obj = VIM.LocalizedMethodFault(
-      :localizedMessage => "The attempted operation cannot be performed in the current state (Powered off).",
+      :localizedMessage => 'The attempted operation cannot be performed in the current state (Powered off).',
       :fault => VIM.InvalidPowerState(
         :requestedState => 'poweredOn',
         :existingState => 'poweredOff',
@@ -138,7 +138,7 @@ end
       )
     )
 
-    check <<-EOS, obj, "LocalizedMethodFault"
+    check <<-EOS, obj, 'LocalizedMethodFault'
 <error xmlns:xsi="#{VIM::NS_XSI}">
   <fault xsi:type="InvalidPowerState">
     <requestedState>poweredOn</requestedState>
@@ -154,7 +154,7 @@ end
       :version => '7',
       :filterSet => [
         VIM.PropertyFilterUpdate(
-          :filter => VIM.PropertyFilter(nil, "session[528BA5EB-335B-4AF6-B49C-6160CF5E8D5B]71E3AC7E-7927-4D9E-8BC3-522769F22DAF"),
+          :filter => VIM.PropertyFilter(nil, 'session[528BA5EB-335B-4AF6-B49C-6160CF5E8D5B]71E3AC7E-7927-4D9E-8BC3-522769F22DAF'),
           :missingSet => [],
           :objectSet => [
             VIM.ObjectUpdate(
@@ -174,7 +174,7 @@ end
       ]
     )
 
-    check <<-EOS, obj, "UpdateSet"
+    check <<-EOS, obj, 'UpdateSet'
 <returnval xmlns:xsi="#{VIM::NS_XSI}">
   <version>7</version>
   <filterSet>
@@ -210,7 +210,7 @@ end
       :driver => 'ata_piix',
       :pci => '00:07.1')
 
-    check <<-EOS, obj, "HostBlockHba"
+    check <<-EOS, obj, 'HostBlockHba'
 <hostBusAdapter xsi:type="HostBlockHba">
   <key>key-vim.host.BlockHba-vmhba0</key>
   <device>vmhba0</device>
@@ -242,18 +242,18 @@ end
   def test_runtime_info
     obj = VIM::VirtualMachineRuntimeInfo(
       :bootTime => Time.parse('2010-08-20 05:44:35 UTC'),
-      :connectionState => "connected",
-      :faultToleranceState => "notConfigured",
+      :connectionState => 'connected',
+      :faultToleranceState => 'notConfigured',
       :featureMask => [],
       :featureRequirement => [],
-      :host => VIM::HostSystem(nil, "host-32"),
+      :host => VIM::HostSystem(nil, 'host-32'),
       :maxCpuUsage => 5612,
       :maxMemoryUsage => 3072,
       :memoryOverhead => 128671744,
       :numMksConnections => 1,
       :offlineFeatureRequirement => [],
-      :powerState => "poweredOn",
-      :recordReplayState => "inactive",
+      :powerState => 'poweredOn',
+      :recordReplayState => 'inactive',
       :suspendInterval => 0,
       :toolsInstallerMounted => false,
       :device => []
@@ -288,17 +288,17 @@ end
   end
 
   def test_boolean
-    check "<root>1</root>", true, 'xsd:boolean'
-    check "<root>true</root>", true, 'xsd:boolean'
-    check "<root>0</root>", false, 'xsd:boolean'
-    check "<root>false</root>", false, 'xsd:boolean'
+    check '<root>1</root>', true, 'xsd:boolean'
+    check '<root>true</root>', true, 'xsd:boolean'
+    check '<root>0</root>', false, 'xsd:boolean'
+    check '<root>false</root>', false, 'xsd:boolean'
   end
 
   def test_int
-    check "<root>5</root>", 5, 'xsd:byte'
-    check "<root>5</root>", 5, 'xsd:short'
-    check "<root>5</root>", 5, 'xsd:int'
-    check "<root>5</root>", 5, 'xsd:long'
+    check '<root>5</root>', 5, 'xsd:byte'
+    check '<root>5</root>', 5, 'xsd:short'
+    check '<root>5</root>', 5, 'xsd:int'
+    check '<root>5</root>', 5, 'xsd:long'
   end
 
   def test_float
@@ -317,7 +317,7 @@ end
   end
 
   def test_array_mangling
-    obj = ["foo"]
+    obj = ['foo']
     check <<-EOS, obj, 'ArrayOfString'
 <root><e>foo</e></root>
     EOS
@@ -337,15 +337,15 @@ end
   end
 
   def test_propertypath
-    check "<root>foo</root>", "foo", 'PropertyPath'
+    check '<root>foo</root>', 'foo', 'PropertyPath'
   end
 
   def test_methodname
-    check "<root>foo</root>", "foo", 'MethodName'
+    check '<root>foo</root>', 'foo', 'MethodName'
   end
 
   def test_typename
-    check "<root>foo</root>", "foo", 'TypeName'
+    check '<root>foo</root>', 'foo', 'TypeName'
   end
 
   def test_new_fields
@@ -358,7 +358,7 @@ end
       :driver => 'ata_piix',
       :pci => '00:07.1')
 
-    check <<-EOS, obj, "HostBlockHba"
+    check <<-EOS, obj, 'HostBlockHba'
 <hostBusAdapter xsi:type="HostBlockHba">
   <key>key-vim.host.BlockHba-vmhba0</key>
   <device>vmhba0</device>

--- a/test/test_emit_request.rb
+++ b/test/test_emit_request.rb
@@ -4,7 +4,7 @@
 require 'test_helper'
 
 class EmitRequestTest < Test::Unit::TestCase
-  MO = VIM::VirtualMachine(nil, "foo")
+  MO = VIM::VirtualMachine(nil, 'foo')
 
   def check desc, str, this, params
     soap = VIM.new(:ns => 'urn:vim25', :rev => '4.0')
@@ -14,10 +14,10 @@ class EmitRequestTest < Test::Unit::TestCase
     begin
       assert_equal str, xml.target!
     rescue Test::Unit::AssertionFailedError
-      puts "expected:"
+      puts 'expected:'
       puts str
       puts
-      puts "got:"
+      puts 'got:'
       puts xml.target!
       puts
       raise

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -25,55 +25,55 @@ class MiscTest < Test::Unit::TestCase
   end
 
   def test_managed_object_to_hash
-    assert_equal VIM.VirtualMachine(nil, "vm-123").to_hash, "VirtualMachine(\"vm-123\")"
+    assert_equal VIM.VirtualMachine(nil, 'vm-123').to_hash, 'VirtualMachine("vm-123")'
   end
 
   def test_managed_object_to_json
-    assert_equal VIM.VirtualMachine(nil, "vm-123").to_json, "\"VirtualMachine(\\\"vm-123\\\")\""
+    assert_equal VIM.VirtualMachine(nil, 'vm-123').to_json, '"VirtualMachine(\\"vm-123\\")"'
   end
 
   def test_data_object_to_hash
     # With a nested ManagedObject value
-    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, "vm-123")}).to_hash, {:vm => "VirtualMachine(\"vm-123\")"}
+    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, 'vm-123')}).to_hash, {:vm => 'VirtualMachine("vm-123")'}
 
     # With an array
     assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).to_hash, {:customValue => [{key: 1}]}
 
     # With an Enum
-    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus("green")}).to_hash, {:overallStatus => "green"}
+    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus('green')}).to_hash, {:overallStatus => 'green'}
 
     # Combined
     assert_equal VIM.VirtualMachineSummary(
-      :vm            => VIM.VirtualMachine(nil, "vm-123"),
+      :vm            => VIM.VirtualMachine(nil, 'vm-123'),
       :customValue   => [VIM.CustomFieldValue(:key => 1)],
-      :overallStatus => VIM.ManagedEntityStatus("green")
+      :overallStatus => VIM.ManagedEntityStatus('green')
     ).to_hash,
     {
-      :vm            => "VirtualMachine(\"vm-123\")",
+      :vm            => 'VirtualMachine("vm-123")',
       :customValue   => [{:key => 1}],
-      :overallStatus => "green"
+      :overallStatus => 'green'
     }
   end
 
   def test_data_object_to_json
     # With a nested ManagedObject value
-    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, "vm-123")}).to_json,
-                 "{\"vm\":\"VirtualMachine(\\\"vm-123\\\")\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, 'vm-123')}).to_json,
+                 '{"vm":"VirtualMachine(\\"vm-123\\")","json_class":"RbVmomi::VIM::VirtualMachineSummary"}'
 
     # With an array
     assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).to_json,
-                 "{\"customValue\":[{\"key\":1}],\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+                 '{"customValue":[{"key":1}],"json_class":"RbVmomi::VIM::VirtualMachineSummary"}'
 
     # With an Enum
-    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus("green")}).to_json,
-                 "{\"overallStatus\":\"green\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus('green')}).to_json,
+                 '{"overallStatus":"green","json_class":"RbVmomi::VIM::VirtualMachineSummary"}'
 
     # Combined
     assert_equal VIM.VirtualMachineSummary(
-      :vm            => VIM.VirtualMachine(nil, "vm-123"),
+      :vm            => VIM.VirtualMachine(nil, 'vm-123'),
       :customValue   => [VIM.CustomFieldValue(:key => 1)],
-      :overallStatus => VIM.ManagedEntityStatus("green")
+      :overallStatus => VIM.ManagedEntityStatus('green')
     ).to_json,
-    "{\"vm\":\"VirtualMachine(\\\"vm-123\\\")\",\"customValue\":[{\"key\":1}],\"overallStatus\":\"green\",\"json_class\":\"RbVmomi::VIM::VirtualMachineSummary\"}"
+    '{"vm":"VirtualMachine(\\"vm-123\\")","customValue":[{"key":1}],"overallStatus":"green","json_class":"RbVmomi::VIM::VirtualMachineSummary"}'
   end
 end

--- a/test/test_parse_response.rb
+++ b/test/test_parse_response.rb
@@ -54,7 +54,7 @@ class ParseResponseTest < Test::Unit::TestCase
       rescue VIM::InvalidArgument
         raise
       rescue
-        raise "wrong fault"
+        raise 'wrong fault'
       end
     end
   end

--- a/test/test_serialization.rb
+++ b/test/test_serialization.rb
@@ -12,10 +12,10 @@ class SerializationTest < Test::Unit::TestCase
     begin
       assert_equal str, xml.target!
     rescue Test::Unit::AssertionFailedError
-      puts "expected:"
+      puts 'expected:'
       puts str
       puts
-      puts "got:"
+      puts 'got:'
       puts xml.target!
       puts
       raise
@@ -23,7 +23,7 @@ class SerializationTest < Test::Unit::TestCase
   end
 
   def test_moref
-    check <<-EOS, VIM.Folder(nil, "ha-folder-host"), "Folder"
+    check <<-EOS, VIM.Folder(nil, 'ha-folder-host'), 'Folder'
 <root type="Folder">ha-folder-host</root>
     EOS
   end
@@ -79,7 +79,7 @@ class SerializationTest < Test::Unit::TestCase
         }
       ]
     )
-    check <<-EOS, cfg, "VirtualMachineConfigSpec"
+    check <<-EOS, cfg, 'VirtualMachineConfigSpec'
 <root xsi:type="VirtualMachineConfigSpec">
   <name>vm</name>
   <guestId>otherGuest64</guestId>
@@ -135,7 +135,7 @@ class SerializationTest < Test::Unit::TestCase
 
   def test_nil_field
     obj = VIM.OptionValue(:key => 'foo', :value => nil)
-    check <<-EOS, obj, "OptionValue"
+    check <<-EOS, obj, 'OptionValue'
 <root xsi:type="OptionValue">
   <key>foo</key>
 </root>
@@ -143,8 +143,8 @@ class SerializationTest < Test::Unit::TestCase
   end
 
   def test_string_array
-    obj = ["foo", "bar", "baz"]
-    check <<-EOS, obj, "xsd:string", true
+    obj = ['foo', 'bar', 'baz']
+    check <<-EOS, obj, 'xsd:string', true
 <root>foo</root>
 <root>bar</root>
 <root>baz</root>
@@ -153,7 +153,7 @@ class SerializationTest < Test::Unit::TestCase
 
   def test_int_array
     obj = [1,2,3]
-    check <<-EOS, obj, "xsd:int", true
+    check <<-EOS, obj, 'xsd:int', true
 <root>1</root>
 <root>2</root>
 <root>3</root>
@@ -162,7 +162,7 @@ class SerializationTest < Test::Unit::TestCase
 
   def test_boolean_array
     obj = [true,false,true]
-    check <<-EOS, obj, "xsd:boolean", true
+    check <<-EOS, obj, 'xsd:boolean', true
 <root>1</root>
 <root>0</root>
 <root>1</root>
@@ -171,7 +171,7 @@ class SerializationTest < Test::Unit::TestCase
 
   def test_float_array
     obj = [0.0,1.5,3.14]
-    check <<-EOS, obj, "xsd:float", true
+    check <<-EOS, obj, 'xsd:float', true
 <root>0.0</root>
 <root>1.5</root>
 <root>3.14</root>
@@ -254,10 +254,10 @@ class SerializationTest < Test::Unit::TestCase
 
   def test_ovf_import_spec_params
     obj = RbVmomi::VIM::OvfCreateImportSpecParams(
-      :hostSystem => VIM::HostSystem(nil, "myhost"),
-      :locale => "US",
-      :entityName => "myvm",
-      :deploymentOption => "",
+      :hostSystem => VIM::HostSystem(nil, 'myhost'),
+      :locale => 'US',
+      :entityName => 'myvm',
+      :deploymentOption => '',
       :networkMapping => [],
       :propertyMapping => [['a', 'b'], ['c', 'd']],
       :diskProvisioning => :thin
@@ -290,7 +290,7 @@ class SerializationTest < Test::Unit::TestCase
   end
 
   def test_time
-    obj = Time.at(DateTime.new(2011, 11, 16, 13, 36, 8, Rational(-8,24)).strftime("%s").to_i).getgm
+    obj = Time.at(DateTime.new(2011, 11, 16, 13, 36, 8, Rational(-8,24)).strftime('%s').to_i).getgm
     check <<-EOS, obj, 'xsd:dateTime', false
 <root>2011-11-16T21:36:08Z</root>
     EOS


### PR DESCRIPTION
Enable the RuboCop Style/StringLiterals cop to catch unnecessary double
quotes around string literals.