### PR TITLE
Add frozen_string_literals comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,4 +12,8 @@ Layout/TrailingWhitespace:
 Layout/HeredocIndentation:
   Enabled: true
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always_true
+
 # inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -542,13 +542,6 @@ Style/FormatString:
 Style/FormatStringToken:
   Enabled: false
 
-# Offense count: 76
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 # Offense count: 17
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2016-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'rbvmomi'

--- a/devel/analyze-vim-declarations.rb
+++ b/devel/analyze-vim-declarations.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/devel/analyze-xml.rb
+++ b/devel/analyze-xml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/devel/benchmark.rb
+++ b/devel/benchmark.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/devel/collisions.rb
+++ b/devel/collisions.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/devel/merge-internal-vmodl.rb
+++ b/devel/merge-internal-vmodl.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/devel/merge-manual-vmodl.rb
+++ b/devel/merge-manual-vmodl.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2013-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/devel/verify-vim-wsdl.rb
+++ b/devel/verify-vim-wsdl.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'active_support/core_ext/enumerable'
 require 'active_support/inflector'

--- a/examples/annotate.rb
+++ b/examples/annotate.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/cached_ovf_deploy.rb
+++ b/examples/cached_ovf_deploy.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/clone_vm.rb
+++ b/examples/clone_vm.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/create_vm-1.9.rb
+++ b/examples/create_vm-1.9.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/create_vm.rb
+++ b/examples/create_vm.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/customAttributes.rb
+++ b/examples/customAttributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Author: Raul Mahiques - Red Hat 2020
 # Based on "annotate.rb" ( https://github.com/vmware/rbvmomi/blob/a5867550bef9535c17f7bedd947fe336151347af/examples/annotate.rb )
 # License MIT ( https://mit-license.org/ )

--- a/examples/delete_disk_from_vm.rb
+++ b/examples/delete_disk_from_vm.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/extraConfig.rb
+++ b/examples/extraConfig.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/lease_tool.rb
+++ b/examples/lease_tool.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/logbundle.rb
+++ b/examples/logbundle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/logtail.rb
+++ b/examples/logtail.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/nfs_datastore.rb
+++ b/examples/nfs_datastore.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/examples/power.rb
+++ b/examples/power.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/readme-1.rb
+++ b/examples/readme-1.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/readme-2.rb
+++ b/examples/readme-2.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/screenshot.rb
+++ b/examples/screenshot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/vdf.rb
+++ b/examples/vdf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/examples/vm_drs_behavior.rb
+++ b/examples/vm_drs_behavior.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT

--- a/exe/rbvmomish
+++ b/exe/rbvmomish
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # TODO keepalive
 # TODO rc file
 # TODO proxy support?

--- a/lib/rbvmomi.rb
+++ b/lib/rbvmomi.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2019 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/fault.rb
+++ b/lib/rbvmomi/fault.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/optimist.rb
+++ b/lib/rbvmomi/optimist.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/pbm.rb
+++ b/lib/rbvmomi/pbm.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/sms.rb
+++ b/lib/rbvmomi/sms.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2013-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/sms/SmsStorageManager.rb
+++ b/lib/rbvmomi/sms/SmsStorageManager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2013-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/sso.rb
+++ b/lib/rbvmomi/sso.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'base64'
 require 'net/https'
 require 'nokogiri'

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/type_loader.rb
+++ b/lib/rbvmomi/type_loader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/utils/admission_control.rb
+++ b/lib/rbvmomi/utils/admission_control.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/utils/deploy.rb
+++ b/lib/rbvmomi/utils/deploy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/utils/leases.rb
+++ b/lib/rbvmomi/utils/leases.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/utils/perfdump.rb
+++ b/lib/rbvmomi/utils/perfdump.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/version.rb
+++ b/lib/rbvmomi/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2016-2020 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ComputeResource.rb
+++ b/lib/rbvmomi/vim/ComputeResource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/Datacenter.rb
+++ b/lib/rbvmomi/vim/Datacenter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/DynamicTypeMgrAllTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrAllTypeInfo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/DynamicTypeMgrDataTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrDataTypeInfo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/DynamicTypeMgrManagedTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrManagedTypeInfo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/HostSystem.rb
+++ b/lib/rbvmomi/vim/HostSystem.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ManagedEntity.rb
+++ b/lib/rbvmomi/vim/ManagedEntity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ManagedObject.rb
+++ b/lib/rbvmomi/vim/ManagedObject.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ObjectContent.rb
+++ b/lib/rbvmomi/vim/ObjectContent.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ObjectUpdate.rb
+++ b/lib/rbvmomi/vim/ObjectUpdate.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/OvfManager.rb
+++ b/lib/rbvmomi/vim/OvfManager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/PerfCounterInfo.rb
+++ b/lib/rbvmomi/vim/PerfCounterInfo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/PerformanceManager.rb
+++ b/lib/rbvmomi/vim/PerformanceManager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2012-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/PropertyCollector.rb
+++ b/lib/rbvmomi/vim/PropertyCollector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ReflectManagedMethodExecuter.rb
+++ b/lib/rbvmomi/vim/ReflectManagedMethodExecuter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ResourcePool.rb
+++ b/lib/rbvmomi/vim/ResourcePool.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/ServiceInstance.rb
+++ b/lib/rbvmomi/vim/ServiceInstance.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/Task.rb
+++ b/lib/rbvmomi/vim/Task.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/lib/rbvmomi/vim/VirtualMachine.rb
+++ b/lib/rbvmomi/vim/VirtualMachine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/rbvmomi.gemspec
+++ b/rbvmomi.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2016-2020 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_deserialization.rb
+++ b/test/test_deserialization.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_emit_request.rb
+++ b/test/test_emit_request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_parse_response.rb
+++ b/test/test_parse_response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 

--- a/test/test_serialization.rb
+++ b/test/test_serialization.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2010-2017 VMware, Inc.  All Rights Reserved.
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
RuboCop autocorrection to add frozen_string_literals comment to the top
of every Ruby file to freeze all string literals.

Signed-off-by: J.R. Garcia <jrg@vmware.com>