### PR TITLE
Use raise instead of fail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,4 +16,8 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true
 
+Style/SignalException:
+  Enabled: true
+  EnforcedStyle: only_raise
+
 # inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -788,13 +788,6 @@ Style/SelfAssignment:
 Style/Semicolon:
   Enabled: false
 
-# Offense count: 71
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: only_raise, only_fail, semantic
-Style/SignalException:
-  Enabled: false
-
 # Offense count: 17
 # Cop supports --auto-correct.
 # Configuration parameters: AllowIfMethodIsEmpty.

--- a/devel/analyze-vim-declarations.rb
+++ b/devel/analyze-vim-declarations.rb
@@ -19,7 +19,7 @@ end
 TYPES = {}
 VERSIONS = []
 
-ID2NAME = Hash.new { |h,k| fail "unknown type-id #{k.inspect}" }
+ID2NAME = Hash.new { |h,k| raise "unknown type-id #{k.inspect}" }
 
 ID2NAME.merge!({
   'java.lang.String' => 'xsd:string',
@@ -188,7 +188,7 @@ TYPES.each do |k,t|
       end
     end
   when 'enum'
-  else fail
+  else raise
   end
 end
 
@@ -209,7 +209,7 @@ if filename = ENV['VERSION_GRAPH']
     VERSIONS.each do |h|
       io.puts "\"#{h['vmodl-name']}\" [label=\"#{h['vmodl-name']} (#{h['version-id']})\"]"
       h['compatible'].each do |x|
-        x =~ /^interface / or fail x
+        x =~ /^interface / or raise x
         io.puts "\"#{h['vmodl-name']}\" -> \"#{$'}\""
       end
     end

--- a/devel/analyze-xml.rb
+++ b/devel/analyze-xml.rb
@@ -31,7 +31,7 @@ def print_tree tree, indent=0
   tree.select { |k,v| k.is_a? String }.sort.each do |k,v|
     attrs = v[:attributes] || []
     min, max = v[:min_occur], v[:max_occur]
-    numsym = if min == 0 and max == 0 then fail
+    numsym = if min == 0 and max == 0 then raise
              elsif min == 0 and max == 1 then '?'
              elsif min == 0 then '*'
              elsif min == 1 and max == 1 then ''

--- a/devel/merge-internal-vmodl.rb
+++ b/devel/merge-internal-vmodl.rb
@@ -51,14 +51,14 @@ internal_vmodl = File.open(internal_vmodl_filename, 'r') { |io| Marshal.load io 
 
 TYPES.each do |k|
   puts "Merging in #{k}"
-  fail "Couldn't find type #{k} in internal VMODL" unless internal_vmodl.member? k
+  raise "Couldn't find type #{k} in internal VMODL" unless internal_vmodl.member? k
   public_vmodl[k] = internal_vmodl[k]
 end
 
 METHODS.each do |x|
   puts "Merging in #{x}"
   type, method = x.split '.'
-  public_vmodl[type]['methods'][method] = internal_vmodl[type]['methods'][method] or fail
+  public_vmodl[type]['methods'][method] = internal_vmodl[type]['methods'][method] or raise
 end
 
 File.open(output_vmodl_filename, 'w') { |io| Marshal.dump public_vmodl, io }

--- a/examples/readme-1.rb
+++ b/examples/readme-1.rb
@@ -34,6 +34,6 @@ Optimist.die('must specify host') unless opts[:host]
 vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = RbVmomi::VIM.connect opts
-dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or fail 'datacenter not found'
-vm = dc.find_vm(vm_name) or fail 'VM not found'
+dc = vim.serviceInstance.find_datacenter(opts[:datacenter]) or raise 'datacenter not found'
+vm = dc.find_vm(vm_name) or raise 'VM not found'
 vm.PowerOnVM_Task.wait_for_completion

--- a/examples/readme-2.rb
+++ b/examples/readme-2.rb
@@ -35,8 +35,8 @@ vm_name = ARGV[0] or abort 'must specify VM name'
 
 vim = RbVmomi::VIM.connect opts
 rootFolder = vim.serviceInstance.content.rootFolder
-dc = rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == opts[:datacenter] } or fail 'datacenter not found'
-vm = dc.vmFolder.childEntity.grep(RbVmomi::VIM::VirtualMachine).find { |x| x.name == vm_name } or fail 'VM not found'
+dc = rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == opts[:datacenter] } or raise 'datacenter not found'
+vm = dc.vmFolder.childEntity.grep(RbVmomi::VIM::VirtualMachine).find { |x| x.name == vm_name } or raise 'VM not found'
 task = vm.PowerOnVM_Task
 filter = vim.propertyCollector.CreateFilter(
   :spec => {

--- a/examples/screenshot.rb
+++ b/examples/screenshot.rb
@@ -45,7 +45,7 @@ dc = vim.serviceInstance.find_datacenter(opts[:datacenter])
 vm = dc.find_vm vm_name
 abort 'VM must be running' unless vm.runtime.powerState == 'poweredOn'
 remote_path = vm.CreateScreenshot_Task.wait_for_completion
-remote_path =~ /^(\/vmfs\/volumes\/[^\/]+)\// or fail
+remote_path =~ /^(\/vmfs\/volumes\/[^\/]+)\// or raise
 datastore_prefix = $1
 datastore_path = $'
 datastore = vm.datastore.find { |ds| ds.info.url == datastore_prefix }

--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -54,11 +54,11 @@ class ObjectWithProperties < Base
   end
 
   def _get_property sym
-    fail 'unimplemented'
+    raise 'unimplemented'
   end
 
   def _set_property sym, val
-    fail 'unimplemented'
+    raise 'unimplemented'
   end
 
   init
@@ -105,7 +105,7 @@ class DataObject < ObjectWithProperties
       #fail "missing required property #{desc['name'].inspect} of #{self.class.wsdl_name}" if @props[desc['name'].to_sym].nil? and not desc['is-optional']
     #end
     @props.each do |k,v|
-      fail "unexpected property name #{k}" unless self.class.find_prop_desc(k)
+      raise "unexpected property name #{k}" unless self.class.find_prop_desc(k)
     end
   end
 
@@ -217,12 +217,12 @@ class ManagedObject < ObjectWithMethods
   end
 
   def _set_property sym, val
-    fail 'unimplemented'
+    raise 'unimplemented'
   end
 
   def _call method, o={}
-    fail 'parameters must be passed as a hash' unless o.is_a? Hash
-    desc = self.class.full_methods_desc[method.to_s] or fail 'unknown method'
+    raise 'parameters must be passed as a hash' unless o.is_a? Hash
+    desc = self.class.full_methods_desc[method.to_s] or raise 'unknown method'
     @connection.call method, desc, self, o
   end
 
@@ -394,7 +394,7 @@ class KeyValue
   def [] i
     if i == 0 then @key
     elsif i == 1 then @value
-    else fail "invalid index #{i.inspect}"
+    else raise "invalid index #{i.inspect}"
     end
   end
 end

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -71,7 +71,7 @@ class NewDeserializer
         leaf_binary node
       when :keyvalue
         leaf_keyvalue node
-      else fail
+      else raise
       end
     else
       if type =~ /:/
@@ -85,7 +85,7 @@ class NewDeserializer
         type = type.split(':', 2)[1]
       end
 
-      klass = @loader.get(type) or fail "no such type '#{type}'"
+      klass = @loader.get(type) or raise "no such type '#{type}'"
       case klass.kind
       when :data
         traverse_data node, klass
@@ -93,7 +93,7 @@ class NewDeserializer
         node.content
       when :managed
         leaf_managed node, klass
-      else fail
+      else raise
       end
     end
   end
@@ -222,8 +222,8 @@ class OldDeserializer
     elsif t == BasicTypes::Binary
       xml.text.unpack('m')[0]
     elsif t == BasicTypes::AnyType
-      fail 'attempted to deserialize an AnyType'
-    else fail "unexpected type #{t.inspect} (#{t.ancestors * '/'})"
+      raise 'attempted to deserialize an AnyType'
+    else raise "unexpected type #{t.inspect} (#{t.ancestors * '/'})"
     end
   rescue
     $stderr.puts "#{$!.class} while deserializing #{xml.name} (#{typename}):"

--- a/lib/rbvmomi/pbm.rb
+++ b/lib/rbvmomi/pbm.rb
@@ -20,7 +20,7 @@ class PBM < Connection
   # @option opts [String]  :path (/pbm/sdk) SDK endpoint path.
   # @option opts [Boolean] :debug (false) If true, print SOAP traffic to stderr.
   def self.connect vim, opts = {}
-    fail unless opts.is_a? Hash
+    raise unless opts.is_a? Hash
     opts[:host] = vim.host
     opts[:ssl] = true unless opts.member? :ssl or opts[:"no-ssl"]
     opts[:insecure] ||= false

--- a/lib/rbvmomi/sms.rb
+++ b/lib/rbvmomi/sms.rb
@@ -19,7 +19,7 @@ class SMS < Connection
   # @option opts [String]  :path (/sms/sdk) SDK endpoint path.
   # @option opts [Boolean] :debug (false) If true, print SOAP traffic to stderr.
   def self.connect vim, opts = {}
-    fail unless opts.is_a? Hash
+    raise unless opts.is_a? Hash
     opts[:host] = vim.host
     opts[:ssl] = true unless opts.member? :ssl or opts[:"no-ssl"]
     opts[:insecure] ||= true

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -13,7 +13,7 @@ class RbVmomi::TrivialSoap
   attr_reader :http
 
   def initialize opts
-    fail unless opts.is_a? Hash
+    raise unless opts.is_a? Hash
     @opts = opts
     return unless @opts[:host] # for testcases
     @debug = @opts[:debug]

--- a/lib/rbvmomi/type_loader.rb
+++ b/lib/rbvmomi/type_loader.rb
@@ -49,13 +49,13 @@ class TypeLoader
   end
 
   def has? name
-    fail unless name.is_a? String
+    raise unless name.is_a? String
 
     @db.member?(name) or BasicTypes::BUILTIN.member?(name)
   end
 
   def get name
-    fail "name '#{name}' is #{name.class} expecting String" unless name.is_a? String
+    raise "name '#{name}' is #{name.class} expecting String" unless name.is_a? String
 
     first_char = name[0].chr
     if first_char.downcase == first_char
@@ -103,12 +103,12 @@ class TypeLoader
   def make_type name
     name = name.to_s
     return BasicTypes.const_get(name) if BasicTypes::BUILTIN.member? name
-    desc = @db[name] or fail "unknown VMODL type #{name}"
+    desc = @db[name] or raise "unknown VMODL type #{name}"
     case desc['kind']
     when 'data' then make_data_type name, desc
     when 'managed' then make_managed_type name, desc
     when 'enum' then make_enum_type name, desc
-    else fail desc.inspect
+    else raise desc.inspect
     end
   end
 

--- a/lib/rbvmomi/utils/admission_control.rb
+++ b/lib/rbvmomi/utils/admission_control.rb
@@ -87,7 +87,7 @@ class AdmissionControlledResourceScheduler
     begin
       @vm_folder ||= datacenter.vmFolder.traverse!(@vm_folder_path, RbVmomi::VIM::Folder)
       if !@vm_folder
-        fail "VM folder #{@vm_folder_path} not found"
+        raise "VM folder #{@vm_folder_path} not found"
       end
     rescue RbVmomi::Fault => fault
       if !fault.fault.is_a?(RbVmomi::VIM::DuplicateName)
@@ -107,7 +107,7 @@ class AdmissionControlledResourceScheduler
     if !@datacenter
       @datacenter = @root_folder.traverse(@datacenter_path, RbVmomi::VIM::Datacenter)
       if !@datacenter
-        fail "datacenter #{@datacenter_path} not found"
+        raise "datacenter #{@datacenter_path} not found"
       end
     end
     @datacenter
@@ -122,7 +122,7 @@ class AdmissionControlledResourceScheduler
       @datastores = @datastore_paths.map do |path|
         ds = datacenter.datastoreFolder.traverse(path, RbVmomi::VIM::Datastore)
         if !ds
-          fail "datastore #{path} not found"
+          raise "datastore #{path} not found"
         end
         ds
       end
@@ -296,7 +296,7 @@ class AdmissionControlledResourceScheduler
       if @service_docs_url
         log "Check #{@service_docs_url} to see which other Pods you may be able to use"
       end
-      fail 'Admission denied'
+      raise 'Admission denied'
     end
     @filtered_pods
   end
@@ -325,7 +325,7 @@ class AdmissionControlledResourceScheduler
       end
 
       if !computer
-        fail 'No clusters available, should have been prevented by admission control'
+        raise 'No clusters available, should have been prevented by admission control'
       end
       @computer = computer
     end
@@ -354,7 +354,7 @@ class AdmissionControlledResourceScheduler
     end
 
     if eligible.length == 0
-      fail "Couldn't find any eligible datastore. Admission control should have prevented this"
+      raise "Couldn't find any eligible datastore. Admission control should have prevented this"
     end
 
     if placementHint && placementHint > 0
@@ -375,7 +375,7 @@ class AdmissionControlledResourceScheduler
 
     @rp = @computer.resourcePool.traverse(@rp_path)
     if !@rp
-      fail "Resource pool #{@rp_path} not found"
+      raise "Resource pool #{@rp_path} not found"
     end
     log "Resource pool: #{@rp.pretty_path}"
 

--- a/lib/rbvmomi/utils/deploy.rb
+++ b/lib/rbvmomi/utils/deploy.rb
@@ -139,7 +139,7 @@ class CachedOvfDeployer
       is_connected && is_ds_accessible && !host_props['runtime.inMaintenanceMode']
     end
     if !host
-      fail 'No host in the cluster available to upload OVF to'
+      raise 'No host in the cluster available to upload OVF to'
     end
 
     log "Uploading OVF to #{hosts_props[host]['name']}..."

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -23,8 +23,8 @@ class VIM < Connection
   # @option opts [Boolean] :close_on_exit (true) If true, will close connection with at_exit
   # @option opts [RbVmomi::SSO] :sso (nil) Use SSO token to login if set
   def self.connect opts
-    fail unless opts.is_a? Hash
-    fail 'host option required' unless opts[:host]
+    raise unless opts.is_a? Hash
+    raise 'host option required' unless opts[:host]
     opts[:cookie] ||= nil
     opts[:user] ||= 'root'
     opts[:password] ||= ''

--- a/lib/rbvmomi/vim/Datastore.rb
+++ b/lib/rbvmomi/vim/Datastore.rb
@@ -20,7 +20,7 @@ class RbVmomi::VIM::Datastore
     when Net::HTTPNotFound
       false
     else
-      fail resp.inspect
+      raise resp.inspect
     end
   end
 
@@ -36,7 +36,7 @@ class RbVmomi::VIM::Datastore
                 url,
                 :out => '/dev/null'
     Process.waitpid(pid, 0)
-    fail 'download failed' unless $?.success?
+    raise 'download failed' unless $?.success?
   end
 
   # Upload a file to this datastore.
@@ -51,7 +51,7 @@ class RbVmomi::VIM::Datastore
                 url,
                 :out => '/dev/null'
     Process.waitpid(pid, 0)
-    fail 'upload failed' unless $?.success?
+    raise 'upload failed' unless $?.success?
   end
 
   private
@@ -62,7 +62,7 @@ class RbVmomi::VIM::Datastore
     while not x.is_a? RbVmomi::VIM::Datacenter
       x = x.parent
     end
-    fail unless x.is_a? RbVmomi::VIM::Datacenter
+    raise unless x.is_a? RbVmomi::VIM::Datacenter
     @datacenter = x
   end
 

--- a/lib/rbvmomi/vim/DynamicTypeMgrAllTypeInfo.rb
+++ b/lib/rbvmomi/vim/DynamicTypeMgrAllTypeInfo.rb
@@ -69,7 +69,7 @@ class RbVmomi::VIM::DynamicTypeMgrAllTypeInfo
           end
         end
       when 'enum'
-      else fail
+      else raise
       end
       [k, t]
     end]

--- a/lib/rbvmomi/vim/Folder.rb
+++ b/lib/rbvmomi/vim/Folder.rb
@@ -89,7 +89,7 @@ class RbVmomi::VIM::Folder
     elsif path.is_a? Enumerable
       es = path
     else
-      fail "unexpected path class #{path.class}"
+      raise "unexpected path class #{path.class}"
     end
     return self if es.empty?
     final = es.pop
@@ -128,12 +128,12 @@ class RbVmomi::VIM::Folder
     propSpecs.each do |k,v|
       case k
       when Class
-        fail 'key must be a subclass of ManagedEntity' unless k < RbVmomi::VIM::ManagedEntity
+        raise 'key must be a subclass of ManagedEntity' unless k < RbVmomi::VIM::ManagedEntity
         k = k.wsdl_name
       when Symbol, String
         k = k.to_s
       else
-        fail 'invalid key'
+        raise 'invalid key'
       end
 
       h = { :type => k }
@@ -142,7 +142,7 @@ class RbVmomi::VIM::Folder
       elsif v.is_a? Array
         h[:pathSet] = v + %w(parent)
       else
-        fail 'value must be an array of property paths or :all'
+        raise 'value must be an array of property paths or :all'
       end
       propSet << h
     end

--- a/lib/rbvmomi/vim/HostSystem.rb
+++ b/lib/rbvmomi/vim/HostSystem.rb
@@ -84,7 +84,7 @@ class VIM::EsxcliNamespace
   end
 
   def realize type, instance, type_info
-    fail if @type or @instance
+    raise if @type or @instance
     @type = type
     @instance = instance
     @type_info = type_info

--- a/lib/rbvmomi/vim/ObjectContent.rb
+++ b/lib/rbvmomi/vim/ObjectContent.rb
@@ -19,7 +19,7 @@ class RbVmomi::VIM::ObjectContent
   def to_hash_uncached
     h = {}
     propSet.each do |x|
-      fail if h.member? x.name
+      raise if h.member? x.name
       h[x.name] = x.val
     end
     h

--- a/lib/rbvmomi/vim/ObjectUpdate.rb
+++ b/lib/rbvmomi/vim/ObjectUpdate.rb
@@ -19,7 +19,7 @@ class RbVmomi::VIM::ObjectUpdate
   def to_hash_uncached
     h = {}
     changeSet.each do |x|
-      fail if h.member? x.name
+      raise if h.member? x.name
       h[x.name] = x.val
     end
     h

--- a/lib/rbvmomi/vim/OvfManager.rb
+++ b/lib/rbvmomi/vim/OvfManager.rb
@@ -27,7 +27,7 @@ class RbVmomi::VIM::OvfManager
              :diskProvisioning => :thin }.merge opts
 
     %w(uri vmName vmFolder host resourcePool datastore).each do |k|
-      fail "parameter #{k} required" unless opts[k.to_sym]
+      raise "parameter #{k} required" unless opts[k.to_sym]
     end
 
     ovfImportSpec = RbVmomi::VIM::OvfCreateImportSpecParams(

--- a/lib/rbvmomi/vim/PerformanceManager.rb
+++ b/lib/rbvmomi/vim/PerformanceManager.rb
@@ -59,7 +59,7 @@ class RbVmomi::VIM::PerformanceManager
       counter = perfcounter_hash[x]
       if !counter
         pp perfcounter_hash.keys
-        fail "Counter for #{x} couldn't be found"
+        raise "Counter for #{x} couldn't be found"
       end
       instances.each do |instance|
         metric_ids << RbVmomi::VIM::PerfMetricId(:counterId => counter.key,


### PR DESCRIPTION
RuboCop autocorrect to always use raise instead of fail to signal an exception.

Signed-off-by: J.R. Garcia <jrg@vmware.com>